### PR TITLE
Add `divan` benchmarks to measure allocations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,17 @@ route-recognizer = "0.3.1"
 routefinder = "0.5.4"
 
 [[bench]]
-name = "matchit"
+name = "matchit_criterion"
 harness = false
 
 [[bench]]
-name = "path_tree"
+name = "matchit_divan"
+harness = false
+
+[[bench]]
+name = "path_tree_criterion"
+harness = false
+
+[[bench]]
+name = "path_tree_divan"
 harness = false

--- a/README.md
+++ b/README.md
@@ -64,68 +64,279 @@ Check out our [codspeed results](https://codspeed.io/DuskSystems/wayfind) for a 
 
 ```
 matchit benchmarks/wayfind
-  time: [238.66 ns 238.92 ns 239.25 ns]
+  time: [170.17 ns 170.52 ns 170.95 ns]
 
 matchit benchmarks/actix-router
-  time: [24.776 µs 24.826 µs 24.882 µs]
+  time: [20.496 µs 20.557 µs 20.625 µs]
 
 matchit benchmarks/gonzales
-  time: [186.88 ns 187.11 ns 187.43 ns]
+  time: [129.23 ns 129.42 ns 129.64 ns]
 
 matchit benchmarks/matchit
-  time: [226.44 ns 226.63 ns 226.90 ns]
+  time: [179.99 ns 180.30 ns 180.67 ns]
 
 matchit benchmarks/ntex-router
-  time: [1.8766 µs 1.8797 µs 1.8834 µs]
+  time: [1.5541 µs 1.5569 µs 1.5603 µs]
 
 matchit benchmarks/path-table
-  time: [654.45 ns 655.11 ns 656.04 ns]
+  time: [535.73 ns 539.85 ns 545.66 ns]
 
 matchit benchmarks/path-tree
-  time: [398.42 ns 399.51 ns 400.71 ns]
+  time: [317.84 ns 318.79 ns 319.77 ns]
 
 matchit benchmarks/regex
-  time: [1.3865 µs 1.3895 µs 1.3926 µs]
+  time: [1.1426 µs 1.1454 µs 1.1484 µs]
 
 matchit benchmarks/route-recognizer
-  time: [5.1563 µs 5.1643 µs 5.1742 µs]
+  time: [4.2810 µs 4.2940 µs 4.3103 µs]
 
 matchit benchmarks/routefinder
-  time: [7.5365 µs 7.6053 µs 7.7237 µs]
+  time: [6.2914 µs 6.2995 µs 6.3092 µs]
+
+matchit allocations
+├─ wayfind           alloc:
+│                      262
+│                      66.97 KB
+│                    dealloc:
+│                      262
+│                      84.48 KB
+│                    grow:
+│                      80
+│                      17.5 KB
+│
+├─ actix-router      alloc:
+│                      31187
+│                      38.03 MB
+│                    dealloc:
+│                      30985
+│                      41.25 MB
+│                    grow:
+│                      6502
+│                      3.228 MB
+│                    shrink:
+│                      183
+│                      526 B
+│
+├─ gonzales          alloc:
+│                      1014
+│                      5.426 MB
+│                    dealloc:
+│                      1014
+│                      5.434 MB
+│                    grow:
+│                      203
+│                      8.272 KB
+│
+├─ matchit           alloc:
+│                      1106
+│                      67.99 KB
+│                    dealloc:
+│                      1106
+│                      89.93 KB
+│                    grow:
+│                      89
+│                      21.93 KB
+│
+├─ ntex-router       alloc:
+│                      36933
+│                      71.99 MB
+│                    dealloc:
+│                      36731
+│                      73.92 MB
+│                    grow:
+│                      6729
+│                      1.93 MB
+│                    shrink:
+│                      6
+│                      23 B
+│
+├─ path-table        alloc:
+│                      406
+│                      39.73 KB
+│                    dealloc:
+│                      406
+│                      39.73 KB
+│
+├─ path-tree         alloc:
+│                      968
+│                      70.79 KB
+│                    dealloc:
+│                      968
+│                      93.03 KB
+│                    grow:
+│                      74
+│                      22.24 KB
+│
+├─ regex             alloc:
+│                      17782
+│                      1.824 MB
+│                    dealloc:
+│                      17782
+│                      3.619 MB
+│                    grow:
+│                      2747
+│                      1.8 MB
+│                    shrink:
+│                      215
+│                      5.938 KB
+│
+├─ route-recognizer  alloc:
+│                      1437
+│                      60.11 KB
+│                    dealloc:
+│                      1437
+│                      222.3 KB
+│                    grow:
+│                      75
+│                      162.2 KB
+│
+╰─ routefinder       alloc:
+                       322
+                       37.74 KB
+                     dealloc:
+                       322
+                       58.74 KB
+                     grow:
+                       131
+                       20.99 KB
 ```
 
 ### [`path-tree` benches](https://github.com/viz-rs/path-tree/blob/v0.8.1/benches/bench.rs)
 
 ```
 path-tree benchmarks/wayfind
-  time: [3.5272 µs 3.5315 µs 3.5368 µs]
+  time: [3.3377 µs 3.3423 µs 3.3476 µs]
 
 path-tree benchmarks/actix-router
-  time: [208.91 µs 209.32 µs 209.80 µs]
+  time: [172.97 µs 173.34 µs 173.76 µs]
 
 path-tree benchmarks/gonzales
-  time: [7.0332 µs 7.0806 µs 7.1247 µs]
+  time: [5.8393 µs 5.8916 µs 5.9629 µs]
 
 path-tree benchmarks/matchit
-  time: [5.8580 µs 5.8653 µs 5.8729 µs]
+  time: [4.8119 µs 4.8198 µs 4.8285 µs]
 
 path-tree benchmarks/ntex-router
-  time: [32.272 µs 32.306 µs 32.347 µs]
+  time: [26.801 µs 26.848 µs 26.907 µs]
 
 path-tree benchmarks/path-table
-  time: [12.286 µs 12.298 µs 12.313 µs]
+  time: [10.195 µs 10.219 µs 10.248 µs]
 
 path-tree benchmarks/path-tree
-  time: [6.3182 µs 6.3274 µs 6.3399 µs]
+  time: [5.1718 µs 5.1810 µs 5.1918 µs]
 
 path-tree benchmarks/regex
-  time: [49.999 µs 50.411 µs 51.097 µs]
+  time: [41.271 µs 41.425 µs 41.605 µs]
 
 path-tree benchmarks/route-recognizer
-  time: [104.09 µs 104.17 µs 104.27 µs]
+  time: [86.283 µs 86.456 µs 86.681 µs]
 
 path-tree benchmarks/routefinder
-  time: [104.76 µs 106.39 µs 109.94 µs]
+  time: [86.989 µs 87.113 µs 87.266 µs]
+
+path-tree allocations
+├─ wayfind           alloc:
+│                      665
+│                      174.5 KB
+│                    dealloc:
+│                      665
+│                      214.3 KB
+│                    grow:
+│                      195
+│                      39.79 KB
+│
+├─ actix-router      alloc:
+│                      78390
+│                      94.92 MB
+│                    dealloc:
+│                      77862
+│                      104.7 MB
+│                    grow:
+│                      16411
+│                      9.872 MB
+│                    shrink:
+│                      510
+│                      1.856 KB
+│
+├─ gonzales          alloc:
+│                      2638
+│                      14.26 MB
+│                    dealloc:
+│                      2638
+│                      14.28 MB
+│                    grow:
+│                      578
+│                      19.53 KB
+│
+├─ matchit           alloc:
+│                      2951
+│                      204.3 KB
+│                    dealloc:
+│                      2951
+│                      261.4 KB
+│                    grow:
+│                      218
+│                      57.03 KB
+│
+├─ ntex-router       alloc:
+│                      97922
+│                      188.5 MB
+│                    dealloc:
+│                      97394
+│                      193.5 MB
+│                    grow:
+│                      17688
+│                      5.016 MB
+│
+├─ path-table        alloc:
+│                      1192
+│                      105.7 KB
+│                    dealloc:
+│                      1192
+│                      105.7 KB
+│
+├─ path-tree         alloc:
+│                      2471
+│                      184.1 KB
+│                    dealloc:
+│                      2471
+│                      233.5 KB
+│                    grow:
+│                      177
+│                      49.44 KB
+│
+├─ regex             alloc:
+│                      48316
+│                      4.547 MB
+│                    dealloc:
+│                      48316
+│                      8.485 MB
+│                    grow:
+│                      6982
+│                      3.942 MB
+│                    shrink:
+│                      568
+│                      4.694 KB
+│
+├─ route-recognizer  alloc:
+│                      6152
+│                      321.2 KB
+│                    dealloc:
+│                      6152
+│                      981.4 KB
+│                    grow:
+│                      268
+│                      660.1 KB
+│
+╰─ routefinder       alloc:
+                       1131
+                       115.8 KB
+                     dealloc:
+                       1131
+                       179.3 KB
+                     grow:
+                       375
+                       63.48 KB
 ```
 
 ## Inspirations

--- a/benches/matchit_criterion.rs
+++ b/benches/matchit_criterion.rs
@@ -3,7 +3,7 @@
 //! Benches sourced from `matchit` (MIT AND BSD-3-Clause)
 //! <https://github.com/ibraheemdev/matchit/blob/v0.8.3/benches/bench.rs>
 
-use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+use codspeed_criterion_compat::{criterion_group, criterion_main, Criterion};
 use matchit_routes::paths;
 
 pub mod matchit_routes;
@@ -18,8 +18,8 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(wayfind.matches(route).unwrap());
+            for route in paths() {
+                wayfind.matches(route).unwrap();
             }
         });
     });
@@ -32,9 +32,9 @@ fn benchmark(criterion: &mut Criterion) {
         let actix = actix.finish();
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
+            for route in paths() {
                 let mut path = actix_router::Path::new(route);
-                black_box(actix.recognize(&mut path).unwrap());
+                actix.recognize(&mut path).unwrap();
             }
         });
     });
@@ -43,8 +43,8 @@ fn benchmark(criterion: &mut Criterion) {
         let gonzales = gonzales::RouterBuilder::new().build(routes!(brackets));
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(gonzales.route(route).unwrap());
+            for route in paths() {
+                gonzales.route(route).unwrap();
             }
         });
     });
@@ -56,8 +56,8 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(matchit.at(route).unwrap());
+            for route in paths() {
+                matchit.at(route).unwrap();
             }
         });
     });
@@ -70,9 +70,9 @@ fn benchmark(criterion: &mut Criterion) {
         let ntex = ntex.finish();
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
+            for route in paths() {
                 let mut path = ntex_router::Path::new(route);
-                black_box(ntex.recognize(&mut path).unwrap());
+                ntex.recognize(&mut path).unwrap();
             }
         });
     });
@@ -84,8 +84,8 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(table.route(route).unwrap());
+            for route in paths() {
+                table.route(route).unwrap();
             }
         });
     });
@@ -97,8 +97,8 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(path_tree.find(route).unwrap());
+            for route in paths() {
+                path_tree.find(route).unwrap();
             }
         });
     });
@@ -107,8 +107,8 @@ fn benchmark(criterion: &mut Criterion) {
         let regex_set = regex::RegexSet::new(routes!(regex)).unwrap();
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(regex_set.matches(route));
+            for route in paths() {
+                regex_set.matches(route);
             }
         });
     });
@@ -120,12 +120,10 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(
-                    route_recognizer
-                        .recognize(route)
-                        .unwrap(),
-                );
+            for route in paths() {
+                route_recognizer
+                    .recognize(route)
+                    .unwrap();
             }
         });
     });
@@ -137,8 +135,8 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for route in black_box(paths()) {
-                black_box(routefinder.best_match(route).unwrap());
+            for route in paths() {
+                routefinder.best_match(route).unwrap();
             }
         });
     });

--- a/benches/matchit_divan.rs
+++ b/benches/matchit_divan.rs
@@ -1,0 +1,134 @@
+//! Benches sourced from `matchit` (MIT AND BSD-3-Clause)
+//! <https://github.com/ibraheemdev/matchit/blob/v0.8.3/benches/bench.rs>
+
+use divan::AllocProfiler;
+use matchit_routes::paths;
+
+pub mod matchit_routes;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench(name = "wayfind")]
+fn wayfind() {
+    let mut wayfind = wayfind::router::Router::new();
+    for route in routes!(brackets) {
+        wayfind.insert(route, true);
+    }
+
+    for route in paths() {
+        wayfind.matches(route).unwrap();
+    }
+}
+
+#[divan::bench(name = "actix-router")]
+fn actix_router() {
+    let mut actix = actix_router::Router::<bool>::build();
+    for route in routes!(brackets) {
+        actix.path(route, true);
+    }
+    let actix = actix.finish();
+
+    for route in paths() {
+        let mut path = actix_router::Path::new(route);
+        actix.recognize(&mut path).unwrap();
+    }
+}
+
+#[divan::bench(name = "gonzales")]
+fn gonzales() {
+    let gonzales = gonzales::RouterBuilder::new().build(routes!(brackets));
+
+    for route in paths() {
+        gonzales.route(route).unwrap();
+    }
+}
+
+#[divan::bench(name = "matchit")]
+fn matchit() {
+    let mut matchit = matchit::Router::new();
+    for route in routes!(brackets) {
+        matchit.insert(route, true).unwrap();
+    }
+
+    for route in paths() {
+        matchit.at(route).unwrap();
+    }
+}
+
+#[divan::bench(name = "ntex-router")]
+fn ntex_router() {
+    let mut ntex = ntex_router::Router::<bool>::build();
+    for route in routes!(brackets) {
+        ntex.path(route, true);
+    }
+    let ntex = ntex.finish();
+
+    for route in paths() {
+        let mut path = ntex_router::Path::new(route);
+        ntex.recognize(&mut path).unwrap();
+    }
+}
+
+#[divan::bench(name = "path-table")]
+fn path_table() {
+    let mut table = path_table::PathTable::new();
+    for route in routes!(brackets) {
+        *table.setup(route) = true;
+    }
+
+    for route in paths() {
+        table.route(route).unwrap();
+    }
+}
+
+#[divan::bench(name = "path-tree")]
+fn path_tree() {
+    let mut path_tree = path_tree::PathTree::new();
+    for route in routes!(colon) {
+        let _ = path_tree.insert(route, true);
+    }
+
+    for route in paths() {
+        path_tree.find(route).unwrap();
+    }
+}
+
+#[divan::bench(name = "regex")]
+fn regex() {
+    let regex_set = regex::RegexSet::new(routes!(regex)).unwrap();
+
+    for route in paths() {
+        regex_set.matches(route);
+    }
+}
+
+#[divan::bench(name = "route-recognizer")]
+fn route_recognizer() {
+    let mut route_recognizer = route_recognizer::Router::new();
+    for route in routes!(colon) {
+        route_recognizer.add(route, true);
+    }
+
+    for route in paths() {
+        route_recognizer
+            .recognize(route)
+            .unwrap();
+    }
+}
+
+#[divan::bench(name = "routefinder")]
+fn routefinder() {
+    let mut routefinder = routefinder::Router::new();
+    for route in routes!(colon) {
+        routefinder.add(route, true).unwrap();
+    }
+
+    for route in paths() {
+        routefinder.best_match(route).unwrap();
+    }
+}

--- a/benches/path_tree_criterion.rs
+++ b/benches/path_tree_criterion.rs
@@ -3,7 +3,7 @@
 //! Benches sourced from `path-tree` (MIT OR Apache-2.0)
 //! <https://github.com/viz-rs/path-tree/blob/v0.8.1/benches/bench.rs>
 
-use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+use codspeed_criterion_compat::{criterion_group, criterion_main, Criterion};
 use path_tree_routes::paths;
 
 pub mod path_tree_routes;
@@ -18,7 +18,7 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = wayfind.matches(path).unwrap();
                 assert_eq!(n.data.value, index);
             }
@@ -33,7 +33,7 @@ fn benchmark(criterion: &mut Criterion) {
         let router = router.finish();
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let mut path = actix_router::Path::new(path);
                 let n = router.recognize(&mut path).unwrap();
                 assert_eq!(*n.0, index);
@@ -45,7 +45,7 @@ fn benchmark(criterion: &mut Criterion) {
         let gonzales = gonzales::RouterBuilder::new().build(routes!(brackets));
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = gonzales.route(path).unwrap();
                 assert_eq!(n.get_index(), index);
             }
@@ -59,7 +59,7 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = matcher.at(path).unwrap();
                 assert_eq!(*n.value, index);
             }
@@ -74,7 +74,7 @@ fn benchmark(criterion: &mut Criterion) {
         let router = router.finish();
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let mut path = ntex_router::Path::new(path);
                 let n = router.recognize(&mut path).unwrap();
                 assert_eq!(*n.0, index);
@@ -89,7 +89,7 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = table.route(path).unwrap();
                 assert_eq!(*n.0, index);
             }
@@ -103,7 +103,7 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = tree.find(path).unwrap();
                 assert_eq!(*n.0, index);
             }
@@ -114,7 +114,7 @@ fn benchmark(criterion: &mut Criterion) {
         let regex_set = regex::RegexSet::new(routes!(regex)).unwrap();
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = regex_set.matches(path);
                 assert!(n.matched(index));
             }
@@ -128,7 +128,7 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = router.recognize(path).unwrap();
                 assert_eq!(**n.handler(), index);
             }
@@ -142,7 +142,7 @@ fn benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for (index, path) in black_box(paths()) {
+            for (index, path) in paths() {
                 let n = router.best_match(path).unwrap();
                 assert_eq!(*n, index);
             }

--- a/benches/path_tree_divan.rs
+++ b/benches/path_tree_divan.rs
@@ -1,0 +1,142 @@
+//! Benches sourced from `path-tree` (MIT OR Apache-2.0)
+//! <https://github.com/viz-rs/path-tree/blob/v0.8.1/benches/bench.rs>
+
+use divan::AllocProfiler;
+use path_tree_routes::paths;
+
+pub mod path_tree_routes;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+fn main() {
+    divan::main();
+}
+
+#[divan::bench(name = "wayfind")]
+fn wayfind() {
+    let mut wayfind = wayfind::router::Router::new();
+    for (index, route) in routes!(brackets).iter().enumerate() {
+        wayfind.insert(route, index);
+    }
+
+    for (index, path) in paths() {
+        let n = wayfind.matches(path).unwrap();
+        assert_eq!(n.data.value, index);
+    }
+}
+
+#[divan::bench(name = "actix-router")]
+fn actix_router() {
+    let mut router = actix_router::Router::<usize>::build();
+    for (index, route) in routes!(brackets).iter().enumerate() {
+        router.path(*route, index);
+    }
+    let router = router.finish();
+
+    for (index, path) in paths() {
+        let mut path = actix_router::Path::new(path);
+        let n = router.recognize(&mut path).unwrap();
+        assert_eq!(*n.0, index);
+    }
+}
+
+#[divan::bench(name = "gonzales")]
+fn gonzales() {
+    let gonzales = gonzales::RouterBuilder::new().build(routes!(brackets));
+
+    for (index, path) in paths() {
+        let n = gonzales.route(path).unwrap();
+        assert_eq!(n.get_index(), index);
+    }
+}
+
+#[divan::bench(name = "matchit")]
+fn matchit() {
+    let mut matcher = matchit::Router::new();
+    for (index, route) in routes!(brackets).iter().enumerate() {
+        let _ = matcher.insert(*route, index);
+    }
+
+    for (index, path) in paths() {
+        let n = matcher.at(path).unwrap();
+        assert_eq!(*n.value, index);
+    }
+}
+
+#[divan::bench(name = "ntex-router")]
+fn ntex_router() {
+    let mut router = ntex_router::Router::<usize>::build();
+    for (index, route) in routes!(brackets).iter().enumerate() {
+        router.path(*route, index);
+    }
+    let router = router.finish();
+
+    for (index, path) in paths() {
+        let mut path = ntex_router::Path::new(path);
+        let n = router.recognize(&mut path).unwrap();
+        assert_eq!(*n.0, index);
+    }
+}
+
+#[divan::bench(name = "path-table")]
+fn path_table() {
+    let mut table = path_table::PathTable::new();
+    for (index, route) in routes!(brackets).iter().enumerate() {
+        *table.setup(route) = index;
+    }
+
+    for (index, path) in paths() {
+        let n = table.route(path).unwrap();
+        assert_eq!(*n.0, index);
+    }
+}
+
+#[divan::bench(name = "path-tree")]
+fn path_tree() {
+    let mut tree = path_tree::PathTree::new();
+    for (index, route) in routes!(colon).iter().enumerate() {
+        let _ = tree.insert(route, index);
+    }
+
+    for (index, path) in paths() {
+        let n = tree.find(path).unwrap();
+        assert_eq!(*n.0, index);
+    }
+}
+
+#[divan::bench(name = "regex")]
+fn regex() {
+    let regex_set = regex::RegexSet::new(routes!(regex)).unwrap();
+
+    for (index, path) in paths() {
+        let n = regex_set.matches(path);
+        assert!(n.matched(index));
+    }
+}
+
+#[divan::bench(name = "route-recognizer")]
+fn route_recognizer() {
+    let mut router = route_recognizer::Router::<usize>::new();
+    for (index, route) in routes!(colon).iter().enumerate() {
+        router.add(route, index);
+    }
+
+    for (index, path) in paths() {
+        let n = router.recognize(path).unwrap();
+        assert_eq!(**n.handler(), index);
+    }
+}
+
+#[divan::bench(name = "routefinder")]
+fn routefinder() {
+    let mut router = routefinder::Router::new();
+    for (index, route) in routes!(colon).iter().enumerate() {
+        router.add(*route, index).unwrap();
+    }
+
+    for (index, path) in paths() {
+        let n = router.best_match(path).unwrap();
+        assert_eq!(*n, index);
+    }
+}


### PR DESCRIPTION
Has to manually edit the output of `divan`, since we're not using it for speed benchmarking.
