### PR TITLE
`no_std` with alloc support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722141560,
-        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
+        "lastModified": 1722802969,
+        "narHash": "sha256-bPhyAXNnVerBZusxOuPMhMm0X7hSFLFKcH+7ynfgLjs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
+        "rev": "785feb91183a50959823ff9ba9ef673105259cd5",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722219664,
-        "narHash": "sha256-xMOJ+HW4yj6e69PvieohUJ3dBSdgCfvI0nnCEe6/yVc=",
+        "lastModified": 1722824458,
+        "narHash": "sha256-2k3/geD5Yh8JT1nrGaRycje5kB0DkvQA/OUZoel1bIU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a6fbda5d9a14fb5f7c69b8489d24afeb349c7bb4",
+        "rev": "a8a937c304e62a5098c6276c9cdf65c19a43b1a5",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
-channel = "1.80.0"
+# FIXME: Once 1.81 releases, switch back to stable.
+channel = "nightly-2024-08-04"
 targets = ["wasm32-unknown-unknown"]
 components = [
   "cargo",

--- a/src/errors/insert.rs
+++ b/src/errors/insert.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt::Display};
+use core::{error::Error, fmt::Display};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum InsertError {
@@ -10,7 +10,7 @@ pub enum InsertError {
 impl Error for InsertError {}
 
 impl Display for InsertError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::InvalidPath => write!(f, "Invalid Path"),
             Self::InvalidRegex => write!(f, "Invalid Regex"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
 pub mod errors;
 pub mod matches;
 pub mod node;

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -1,5 +1,6 @@
 use crate::node::NodeData;
-use std::fmt::Debug;
+use alloc::vec::Vec;
+use core::fmt::Debug;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Match<'a, T> {

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,7 +2,13 @@ use crate::{
     matches::Parameter,
     parts::{Part, Parts},
 };
-use std::{fmt::Display, sync::Arc};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::fmt::Display;
 
 #[cfg(regex)]
 use regex::bytes::Regex;
@@ -135,12 +141,12 @@ impl<T> Node<T> {
             prefix: child.prefix[common_prefix..].to_vec(),
             data: child.data.take(),
 
-            static_children: std::mem::take(&mut child.static_children),
+            static_children: core::mem::take(&mut child.static_children),
             #[cfg(regex)]
-            regex_children: std::mem::take(&mut child.regex_children),
-            dynamic_children: std::mem::take(&mut child.dynamic_children),
-            wildcard_children: std::mem::take(&mut child.wildcard_children),
-            end_wildcard: std::mem::take(&mut child.end_wildcard),
+            regex_children: core::mem::take(&mut child.regex_children),
+            dynamic_children: core::mem::take(&mut child.dynamic_children),
+            wildcard_children: core::mem::take(&mut child.wildcard_children),
+            end_wildcard: core::mem::take(&mut child.end_wildcard),
 
             #[cfg(regex)]
             quick_regex: false,
@@ -672,14 +678,14 @@ impl<T> Node<T> {
 // FIXME: Doesn't handle split multi-byte characters.
 impl<T: Display> Display for Node<T> {
     #[allow(clippy::too_many_lines)]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         fn debug_node<T: Display>(
-            f: &mut std::fmt::Formatter,
+            f: &mut core::fmt::Formatter,
             node: &Node<T>,
             padding: &str,
             is_root: bool,
             is_last: bool,
-        ) -> std::fmt::Result {
+        ) -> core::fmt::Result {
             let key = match &node.kind {
                 NodeKind::Root => "$",
                 NodeKind::Static => &String::from_utf8_lossy(&node.prefix),

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -1,5 +1,6 @@
 use crate::errors::insert::InsertError;
-use std::fmt::Debug;
+use alloc::vec::Vec;
+use core::fmt::Debug;
 
 #[cfg(regex)]
 use regex::bytes::Regex;

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,7 +4,8 @@ use crate::{
     node::{Node, NodeData, NodeKind},
     parts::Parts,
 };
-use std::{fmt::Display, sync::Arc};
+use alloc::sync::Arc;
+use core::fmt::Display;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Router<T> {
@@ -13,7 +14,7 @@ pub struct Router<T> {
 
 impl<T> Router<T> {
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             root: Node {
                 kind: NodeKind::Root,
@@ -65,7 +66,7 @@ impl<T> Default for Router<T> {
 }
 
 impl<T: Display> Display for Router<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.root)
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -2,7 +2,7 @@ use crate::{
     matches::{Match, Parameter},
     router::Router,
 };
-use std::{fmt::Debug, sync::Arc};
+use alloc::{fmt::Debug, sync::Arc, vec::Vec};
 
 #[macro_export]
 macro_rules! assert_router_matches {


### PR DESCRIPTION
Proof of concept of how easy no_std + alloc support will be once 1.81 comes out.

Not sure we'd want to raise the msrv, however.