### PR TITLE
Experiment with 'extractor' like constraints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,8 +45,9 @@
   // rust-lang.rust-analyzer
   "rust-analyzer.server.path": "rust-analyzer",
   "rust-analyzer.cargo.features": "all",
-  "rust-analyzer.checkOnSave": true,
   "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.workspace": false,
+  "rust-analyzer.checkOnSave": true,
 
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"

--- a/README.md
+++ b/README.md
@@ -33,37 +33,37 @@ Check out our [codspeed results](https://codspeed.io/DuskSystems/wayfind/benchma
 
 ```
 matchit benchmarks/wayfind
-  time: [187.94 ns 188.34 ns 188.83 ns]
+  time: [205.06 ns 205.32 ns 205.66 ns]
 
 matchit benchmarks/actix-router
-  time: [20.865 µs 20.934 µs 21.005 µs]
+  time: [21.087 µs 21.264 µs 21.440 µs]
 
 matchit benchmarks/gonzales
-  time: [129.49 ns 129.75 ns 130.04 ns]
+  time: [129.58 ns 130.01 ns 130.50 ns]
 
 matchit benchmarks/matchit
-  time: [180.83 ns 181.24 ns 181.68 ns]
+  time: [180.11 ns 180.46 ns 180.94 ns]
 
 matchit benchmarks/ntex-router
-  time: [1.5656 µs 1.5695 µs 1.5738 µs]
+  time: [1.5558 µs 1.5605 µs 1.5656 µs]
 
 matchit benchmarks/path-table
-  time: [527.84 ns 534.22 ns 547.03 ns]
+  time: [539.10 ns 540.01 ns 541.06 ns]
 
 matchit benchmarks/path-tree
-  time: [316.98 ns 317.53 ns 318.10 ns]
+  time: [312.92 ns 313.57 ns 314.35 ns]
 
 matchit benchmarks/regex
-  time: [1.1470 µs 1.1500 µs 1.1534 µs]
+  time: [1.1500 µs 1.1621 µs 1.1833 µs]
 
 matchit benchmarks/route-recognizer
-  time: [4.3378 µs 4.4165 µs 4.5313 µs]
+  time: [4.3255 µs 4.3450 µs 4.3664 µs]
 
 matchit benchmarks/routefinder
-  time: [6.0553 µs 6.0686 µs 6.0839 µs]
+  time: [6.0104 µs 6.0235 µs 6.0387 µs]
 
 matchit benchmarks/xitca-router
-  time: [352.52 ns 353.23 ns 354.07 ns]
+  time: [352.04 ns 352.75 ns 353.61 ns]
 
 matchit allocations
 ├─ wayfind           alloc:
@@ -71,7 +71,7 @@ matchit allocations
 │                      97.43 KB
 │                    dealloc:
 │                      654
-│                      100.9 KB
+│                      116.5 KB
 │                    grow:
 │                      80
 │                      19.13 KB
@@ -189,48 +189,48 @@ matchit allocations
 
 ```
 path-tree benchmarks/wayfind
-  time: [3.2152 µs 3.2230 µs 3.2327 µs]
+  time: [3.1300 µs 3.1345 µs 3.1398 µs]
 
 path-tree benchmarks/actix-router
-  time: [174.12 µs 174.68 µs 175.26 µs]
+  time: [175.08 µs 177.90 µs 183.39 µs]
 
 path-tree benchmarks/gonzales
-  time: [5.7948 µs 5.8332 µs 5.8714 µs]
+  time: [5.7293 µs 5.7671 µs 5.8043 µs]
 
 path-tree benchmarks/matchit
-  time: [4.8233 µs 4.8351 µs 4.8491 µs]
+  time: [4.8003 µs 4.8068 µs 4.8146 µs]
 
 path-tree benchmarks/ntex-router
-  time: [26.562 µs 26.630 µs 26.705 µs]
+  time: [26.451 µs 26.509 µs 26.582 µs]
 
 path-tree benchmarks/path-table
-  time: [10.259 µs 10.292 µs 10.329 µs]
+  time: [10.299 µs 10.323 µs 10.351 µs]
 
 path-tree benchmarks/path-tree
-  time: [5.3023 µs 5.3153 µs 5.3295 µs]
+  time: [5.2089 µs 5.2175 µs 5.2274 µs]
 
 path-tree benchmarks/regex
-  time: [41.462 µs 41.606 µs 41.778 µs]
+  time: [41.535 µs 41.685 µs 41.874 µs]
 
 path-tree benchmarks/route-recognizer
-  time: [85.986 µs 86.163 µs 86.368 µs]
+  time: [86.125 µs 86.327 µs 86.578 µs]
 
 path-tree benchmarks/routefinder
-  time: [92.163 µs 92.331 µs 92.534 µs]
+  time: [91.673 µs 91.784 µs 91.906 µs]
 
 path-tree benchmarks/xitca-router
-  time: [7.3373 µs 7.3539 µs 7.3741 µs]
+  time: [7.3105 µs 7.3279 µs 7.3501 µs]
 
 path-tree allocations
 ├─ wayfind           alloc:
 │                      1619
-│                      268.1 KB
+│                      258.5 KB
 │                    dealloc:
 │                      1619
-│                      308.7 KB
+│                      298.1 KB
 │                    grow:
 │                      195
-│                      40.65 KB
+│                      39.55 KB
 │
 ├─ actix-router      alloc:
 │                      78390

--- a/benches/matchit_routes.rs
+++ b/benches/matchit_routes.rs
@@ -18,7 +18,6 @@ macro_rules! routes {
         routes!(finish => "{p1}", "{p2}", "{p3}", "{p4}")
     }};
 
-
     (chevrons) => {{
         routes!(finish => "<p1>", "<p2>", "<p3>", "<p4>")
     }};

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,18 +17,26 @@ pub enum NodeKind {
     EndWildcard,
 }
 
+pub trait Constraint {
+    fn name() -> &'static str;
+    fn check(segment: &str) -> bool;
+}
+
 #[derive(Clone)]
-pub struct NodeConstraint(pub fn(&str) -> bool);
+pub struct NodeConstraint {
+    pub name: &'static str,
+    pub check: fn(&str) -> bool,
+}
 
 impl Debug for NodeConstraint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "NodeConstraint(<function>)")
+        write!(f, "{}", self.name)
     }
 }
 
 impl PartialEq for NodeConstraint {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0 as *const (), other.0 as *const ())
+        self.name == other.name && std::ptr::eq(self.check as *const (), other.check as *const ())
     }
 }
 
@@ -46,7 +54,7 @@ pub struct Node<T> {
 
     pub prefix: Vec<u8>,
     pub data: Option<NodeData<T>>,
-    pub constraints: Vec<NodeConstraint>,
+    pub constraint: Option<NodeConstraint>,
 
     pub static_children: Vec<Node<T>>,
     pub dynamic_children: Vec<Node<T>>,

--- a/src/node/delete.rs
+++ b/src/node/delete.rs
@@ -12,15 +12,15 @@ impl<T> Node<T> {
                 Part::Static { prefix } => self.delete_static(route, prefix),
                 Part::Dynamic { name } => {
                     let constraint = route.constraints.remove(name);
-                    self.delete_dynamic(route, name, constraint)
+                    self.delete_dynamic(route, name, &constraint)
                 }
                 Part::Wildcard { name } if route.parts.is_empty() => {
                     let constraint = route.constraints.remove(name);
-                    self.delete_end_wildcard(name, constraint)
+                    self.delete_end_wildcard(name, &constraint)
                 }
                 Part::Wildcard { name } => {
                     let constraint = route.constraints.remove(name);
-                    self.delete_wildcard(route, name, constraint)
+                    self.delete_wildcard(route, name, &constraint)
                 }
             };
 
@@ -73,18 +73,16 @@ impl<T> Node<T> {
         result
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn delete_dynamic(
         &mut self,
         route: &mut Route<'_>,
         name: &[u8],
-
-        constraint: Option<NodeConstraint>,
+        constraint: &Option<NodeConstraint>,
     ) -> Result<(), DeleteError> {
         let index = self
             .dynamic_children
             .iter()
-            .position(|child| child.prefix == name && child.constraint == constraint)
+            .position(|child| child.prefix == name && child.constraint == *constraint)
             .ok_or(DeleteError::NotFound)?;
 
         let child = &mut self.dynamic_children[index];
@@ -101,17 +99,16 @@ impl<T> Node<T> {
         result
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn delete_wildcard(
         &mut self,
         route: &mut Route<'_>,
         name: &[u8],
-        constraint: Option<NodeConstraint>,
+        constraint: &Option<NodeConstraint>,
     ) -> Result<(), DeleteError> {
         let index = self
             .wildcard_children
             .iter()
-            .position(|child| child.prefix == name && child.constraint == constraint)
+            .position(|child| child.prefix == name && child.constraint == *constraint)
             .ok_or(DeleteError::NotFound)?;
 
         let child = &mut self.wildcard_children[index];
@@ -128,12 +125,11 @@ impl<T> Node<T> {
         result
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn delete_end_wildcard(&mut self, name: &[u8], constraint: Option<NodeConstraint>) -> Result<(), DeleteError> {
+    fn delete_end_wildcard(&mut self, name: &[u8], constraint: &Option<NodeConstraint>) -> Result<(), DeleteError> {
         let index = self
             .end_wildcard_children
             .iter()
-            .position(|child| child.prefix == name && child.constraint == constraint)
+            .position(|child| child.prefix == name && child.constraint == *constraint)
             .ok_or(DeleteError::NotFound)?;
 
         self.end_wildcard_children.remove(index);

--- a/src/node/display.rs
+++ b/src/node/display.rs
@@ -28,20 +28,18 @@ impl<T: Display> Display for Node<T> {
             let value = node
                 .data
                 .as_ref()
-                .map(|node_data| &node_data.value);
+                .map_or(String::new(), |node_data| format!(" [{}]", node_data.value));
 
-            let constraints = if node.constraints.is_empty() {
-                String::new()
-            } else {
-                format!(" {:?}", node.constraints)
-            };
+            let constraint = node
+                .constraint
+                .as_ref()
+                .map_or(String::new(), |c| format!(" ({c:?})"));
 
             if is_root {
                 writeln!(f, "{key}")?;
             } else {
                 let branch = if is_last { "╰─" } else { "├─" };
-                let value = value.map_or(String::new(), |v| format!(" [{v}]"));
-                writeln!(f, "{padding}{branch} {key}{value}{constraints}")?;
+                writeln!(f, "{padding}{branch} {key}{value}{constraint}")?;
             }
 
             // Ensure we align children correctly

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,7 +9,7 @@ use std::{fmt::Display, sync::Arc};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Router<T> {
-    root: Node<T>,
+    pub root: Node<T>,
 }
 
 impl<T> Router<T> {
@@ -21,7 +21,7 @@ impl<T> Router<T> {
 
                 prefix: vec![],
                 data: None,
-                constraints: vec![],
+                constraint: None,
 
                 static_children: vec![],
                 dynamic_children: vec![],
@@ -55,11 +55,14 @@ impl<T> Router<T> {
     #[must_use]
     pub fn matches<'k, 'v>(&'k self, path: &'v str) -> Option<Match<'k, 'v, T>> {
         let mut parameters = smallvec![];
-        let data = self
+        let node = self
             .root
             .matches(path.as_bytes(), &mut parameters)?;
 
-        Some(Match { data, parameters })
+        Some(Match {
+            data: node.data.as_ref()?,
+            parameters,
+        })
     }
 }
 

--- a/tests/matchit_delete.rs
+++ b/tests/matchit_delete.rs
@@ -27,11 +27,6 @@ fn normalized() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ x/
-       │   ├─ <foo>
-       │   │      ╰─ /bar [0]
-       │   ╰─ <bar>
-       │          ╰─ /baz [1]
        ├─ s [8]
        │  ╰─ /s [9]
        │      ╰─ /
@@ -41,13 +36,15 @@ fn normalized() -> Result<(), Box<dyn Error>> {
        │         │    ╰─ /x [12]
        │         ╰─ <y>
        │              ╰─ /d [13]
-       ├─ <foo>
+       ├─ x/
+       │   ├─ <bar>
+       │   │      ╰─ /baz [1]
+       │   ╰─ <foo>
+       │          ╰─ /bar [0]
+       ├─ <bar>
        │      ╰─ /
-       │         ├─ baz/bax [6]
-       │         ├─ <baz>
-       │         │      ╰─ /bax [2]
-       │         ╰─ <bar>
-       │                ╰─ /baz [3]
+       │         ╰─ <bay>
+       │                ╰─ /bay [7]
        ├─ <fod>
        │      ╰─ /
        │         ├─ baz/bax/foo [5]
@@ -55,10 +52,13 @@ fn normalized() -> Result<(), Box<dyn Error>> {
        │                ╰─ /
        │                   ╰─ <bax>
        │                          ╰─ /foo [4]
-       ╰─ <bar>
+       ╰─ <foo>
               ╰─ /
-                 ╰─ <bay>
-                        ╰─ /bay [7]
+                 ├─ baz/bax [6]
+                 ├─ <bar>
+                 │      ╰─ /baz [3]
+                 ╰─ <baz>
+                        ╰─ /bax [2]
     "###);
 
     assert_eq!(router.delete("/x/<foo>/bar"), Ok(()));
@@ -121,6 +121,7 @@ fn blog() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ favicon.ico [5]
        ├─ posts/
        │       ╰─ <year>
        │               ╰─ /
@@ -131,7 +132,6 @@ fn blog() -> Result<(), Box<dyn Error>> {
        │                              ╰─ <post> [1]
        ├─ static/
        │        ╰─ <path:*> [4]
-       ├─ favicon.ico [5]
        ╰─ <page> [0]
     "###);
 
@@ -160,11 +160,11 @@ fn catchall() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <catchall:*> [0]
-       ╰─ bar [1]
-            ╰─ / [2]
-               ╰─ <catchall:*> [3]
+       ├─ bar [1]
+       │    ╰─ / [2]
+       │       ╰─ <catchall:*> [3]
+       ╰─ foo/
+             ╰─ <catchall:*> [0]
     "###);
 
     assert_eq!(router.delete("/foo/<catchall:*>"), Ok(()));
@@ -219,20 +219,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [0]
        │     ╰─ /
        │        ╰─ <id> [1]
-       ├─ users [2]
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [2]
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     assert_eq!(router.delete("/home"), Ok(()));
@@ -240,20 +240,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home
        │     ╰─ /
        │        ╰─ <id> [1]
-       ├─ users [2]
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [2]
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     router.insert("/home", 9)?;
@@ -261,20 +261,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [1]
-       ├─ users [2]
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [2]
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     assert_eq!(router.delete("/home/<id>"), Ok(()));
@@ -282,18 +282,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
-       ├─ users [2]
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [2]
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     router.insert("/home/<id>", 10)?;
@@ -301,20 +301,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [2]
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [2]
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     assert_eq!(router.delete("/users"), Ok(()));
@@ -322,20 +322,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     router.insert("/users", 11)?;
@@ -343,20 +343,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [3]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [3]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     assert_eq!(router.delete("/users/<id>"), Ok(()));
@@ -364,20 +364,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id>
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id>
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     router.insert("/users/<id>", 12)?;
@@ -385,20 +385,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [4]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [4]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     assert_eq!(router.delete("/users/<id>/posts"), Ok(()));
@@ -406,20 +406,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     router.insert("/users/<id>/posts", 13)?;
@@ -427,20 +427,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [5]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [5]
     "###);
 
     assert_eq!(router.delete("/users/<id>/posts/<post_id>"), Ok(()));
@@ -448,18 +448,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
     "###);
 
     router.insert("/users/<id>/posts/<post_id>", 14)?;
@@ -467,20 +467,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [6]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles [6]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     assert_eq!(router.delete("/articles"), Ok(()));
@@ -488,20 +488,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     router.insert("/articles", 15)?;
@@ -509,20 +509,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [15]
+       │         ╰─ /
+       │            ╰─ <category> [7]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles [15]
-                 ╰─ /
-                    ╰─ <category> [7]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     assert_eq!(router.delete("/articles/<category>"), Ok(()));
@@ -530,20 +530,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [15]
+       │         ╰─ /
+       │            ╰─ <category>
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles [15]
-                 ╰─ /
-                    ╰─ <category>
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     router.insert("/articles/<category>", 16)?;
@@ -551,20 +551,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [15]
+       │         ╰─ /
+       │            ╰─ <category> [16]
+       │                        ╰─ /
+       │                           ╰─ <id> [8]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles [15]
-                 ╰─ /
-                    ╰─ <category> [16]
-                                ╰─ /
-                                   ╰─ <id> [8]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     assert_eq!(router.delete("/articles/<category>/<id>"), Ok(()));
@@ -572,18 +572,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [15]
+       │         ╰─ /
+       │            ╰─ <category> [16]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles [15]
-                 ╰─ /
-                    ╰─ <category> [16]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     router.insert("/articles/<category>/<id>", 17)?;
@@ -591,20 +591,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ articles [15]
+       │         ╰─ /
+       │            ╰─ <category> [16]
+       │                        ╰─ /
+       │                           ╰─ <id> [17]
        ├─ home [9]
        │     ╰─ /
        │        ╰─ <id> [10]
-       ├─ users [11]
-       │      ╰─ /
-       │         ╰─ <id> [12]
-       │               ╰─ /posts [13]
-       │                       ╰─ /
-       │                          ╰─ <post_id> [14]
-       ╰─ articles [15]
-                 ╰─ /
-                    ╰─ <category> [16]
-                                ╰─ /
-                                   ╰─ <id> [17]
+       ╰─ users [11]
+              ╰─ /
+                 ╰─ <id> [12]
+                       ╰─ /posts [13]
+                               ╰─ /
+                                  ╰─ <post_id> [14]
     "###);
 
     Ok(())
@@ -712,21 +712,21 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <id> [0]
-       │           ╰─ /bar [1]
-       ╰─ ba
-           ├─ r/
-           │   ╰─ <user>
-           │           ╰─ /
-           │              ╰─ <id> [2]
-           │                    ╰─ /baz [3]
-           ╰─ z/
-               ╰─ <product>
-                          ╰─ /
-                             ╰─ <user>
-                                     ╰─ /
-                                        ╰─ <id> [4]
+       ├─ ba
+       │   ├─ r/
+       │   │   ╰─ <user>
+       │   │           ╰─ /
+       │   │              ╰─ <id> [2]
+       │   │                    ╰─ /baz [3]
+       │   ╰─ z/
+       │       ╰─ <product>
+       │                  ╰─ /
+       │                     ╰─ <user>
+       │                             ╰─ /
+       │                                ╰─ <id> [4]
+       ╰─ foo/
+             ╰─ <id> [0]
+                   ╰─ /bar [1]
     "###);
 
     assert_eq!(router.delete("/foo/<a>"), Err(DeleteError::NotFound));
@@ -734,21 +734,21 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <id> [0]
-       │           ╰─ /bar [1]
-       ╰─ ba
-           ├─ r/
-           │   ╰─ <user>
-           │           ╰─ /
-           │              ╰─ <id> [2]
-           │                    ╰─ /baz [3]
-           ╰─ z/
-               ╰─ <product>
-                          ╰─ /
-                             ╰─ <user>
-                                     ╰─ /
-                                        ╰─ <id> [4]
+       ├─ ba
+       │   ├─ r/
+       │   │   ╰─ <user>
+       │   │           ╰─ /
+       │   │              ╰─ <id> [2]
+       │   │                    ╰─ /baz [3]
+       │   ╰─ z/
+       │       ╰─ <product>
+       │                  ╰─ /
+       │                     ╰─ <user>
+       │                             ╰─ /
+       │                                ╰─ <id> [4]
+       ╰─ foo/
+             ╰─ <id> [0]
+                   ╰─ /bar [1]
     "###);
 
     assert_eq!(router.delete("/foo/<a>/bar"), Err(DeleteError::NotFound));
@@ -756,21 +756,21 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <id> [0]
-       │           ╰─ /bar [1]
-       ╰─ ba
-           ├─ r/
-           │   ╰─ <user>
-           │           ╰─ /
-           │              ╰─ <id> [2]
-           │                    ╰─ /baz [3]
-           ╰─ z/
-               ╰─ <product>
-                          ╰─ /
-                             ╰─ <user>
-                                     ╰─ /
-                                        ╰─ <id> [4]
+       ├─ ba
+       │   ├─ r/
+       │   │   ╰─ <user>
+       │   │           ╰─ /
+       │   │              ╰─ <id> [2]
+       │   │                    ╰─ /baz [3]
+       │   ╰─ z/
+       │       ╰─ <product>
+       │                  ╰─ /
+       │                     ╰─ <user>
+       │                             ╰─ /
+       │                                ╰─ <id> [4]
+       ╰─ foo/
+             ╰─ <id> [0]
+                   ╰─ /bar [1]
     "###);
 
     assert_eq!(router.delete("/bar/<a>/<b>"), Err(DeleteError::NotFound));
@@ -778,21 +778,21 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <id> [0]
-       │           ╰─ /bar [1]
-       ╰─ ba
-           ├─ r/
-           │   ╰─ <user>
-           │           ╰─ /
-           │              ╰─ <id> [2]
-           │                    ╰─ /baz [3]
-           ╰─ z/
-               ╰─ <product>
-                          ╰─ /
-                             ╰─ <user>
-                                     ╰─ /
-                                        ╰─ <id> [4]
+       ├─ ba
+       │   ├─ r/
+       │   │   ╰─ <user>
+       │   │           ╰─ /
+       │   │              ╰─ <id> [2]
+       │   │                    ╰─ /baz [3]
+       │   ╰─ z/
+       │       ╰─ <product>
+       │                  ╰─ /
+       │                     ╰─ <user>
+       │                             ╰─ /
+       │                                ╰─ <id> [4]
+       ╰─ foo/
+             ╰─ <id> [0]
+                   ╰─ /bar [1]
     "###);
 
     assert_eq!(router.delete("/bar/<a>/<b>/baz"), Err(DeleteError::NotFound));
@@ -800,21 +800,21 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <id> [0]
-       │           ╰─ /bar [1]
-       ╰─ ba
-           ├─ r/
-           │   ╰─ <user>
-           │           ╰─ /
-           │              ╰─ <id> [2]
-           │                    ╰─ /baz [3]
-           ╰─ z/
-               ╰─ <product>
-                          ╰─ /
-                             ╰─ <user>
-                                     ╰─ /
-                                        ╰─ <id> [4]
+       ├─ ba
+       │   ├─ r/
+       │   │   ╰─ <user>
+       │   │           ╰─ /
+       │   │              ╰─ <id> [2]
+       │   │                    ╰─ /baz [3]
+       │   ╰─ z/
+       │       ╰─ <product>
+       │                  ╰─ /
+       │                     ╰─ <user>
+       │                             ╰─ /
+       │                                ╰─ <id> [4]
+       ╰─ foo/
+             ╰─ <id> [0]
+                   ╰─ /bar [1]
     "###);
 
     assert_eq!(router.delete("/baz/<a>/<b>/<c>"), Err(DeleteError::NotFound));
@@ -822,21 +822,21 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <id> [0]
-       │           ╰─ /bar [1]
-       ╰─ ba
-           ├─ r/
-           │   ╰─ <user>
-           │           ╰─ /
-           │              ╰─ <id> [2]
-           │                    ╰─ /baz [3]
-           ╰─ z/
-               ╰─ <product>
-                          ╰─ /
-                             ╰─ <user>
-                                     ╰─ /
-                                        ╰─ <id> [4]
+       ├─ ba
+       │   ├─ r/
+       │   │   ╰─ <user>
+       │   │           ╰─ /
+       │   │              ╰─ <id> [2]
+       │   │                    ╰─ /baz [3]
+       │   ╰─ z/
+       │       ╰─ <product>
+       │                  ╰─ /
+       │                     ╰─ <user>
+       │                             ╰─ /
+       │                                ╰─ <id> [4]
+       ╰─ foo/
+             ╰─ <id> [0]
+                   ╰─ /bar [1]
     "###);
 
     Ok(())

--- a/tests/matchit_matches.rs
+++ b/tests/matchit_matches.rs
@@ -16,8 +16,8 @@ fn partial_overlap() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /foo
-          ├─ _bar [Welcome!]
-          ╰─ /bar [Welcome!]
+          ├─ /bar [Welcome!]
+          ╰─ _bar [Welcome!]
     "###);
 
     assert_router_matches!(router, {
@@ -231,11 +231,6 @@ fn normalized() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ x/
-       │   ├─ <foo>
-       │   │      ╰─ /bar [1]
-       │   ╰─ <bar>
-       │          ╰─ /baz [2]
        ├─ s [9]
        │  ╰─ /s [10]
        │      ╰─ /
@@ -245,13 +240,15 @@ fn normalized() -> Result<(), Box<dyn Error>> {
        │         │    ╰─ /x [13]
        │         ╰─ <y>
        │              ╰─ /d [14]
-       ├─ <foo>
+       ├─ x/
+       │   ├─ <bar>
+       │   │      ╰─ /baz [2]
+       │   ╰─ <foo>
+       │          ╰─ /bar [1]
+       ├─ <bar>
        │      ╰─ /
-       │         ├─ baz/bax [7]
-       │         ├─ <baz>
-       │         │      ╰─ /bax [3]
-       │         ╰─ <bar>
-       │                ╰─ /baz [4]
+       │         ╰─ <bay>
+       │                ╰─ /bay [8]
        ├─ <fod>
        │      ╰─ /
        │         ├─ baz/bax/foo [6]
@@ -259,10 +256,13 @@ fn normalized() -> Result<(), Box<dyn Error>> {
        │                ╰─ /
        │                   ╰─ <bax>
        │                          ╰─ /foo [5]
-       ╰─ <bar>
+       ╰─ <foo>
               ╰─ /
-                 ╰─ <bay>
-                        ╰─ /bay [8]
+                 ├─ baz/bax [7]
+                 ├─ <bar>
+                 │      ╰─ /baz [4]
+                 ╰─ <baz>
+                        ╰─ /bax [3]
     "###);
 
     assert_router_matches!(router, {
@@ -383,6 +383,7 @@ fn blog() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
+       ├─ favicon.ico [6]
        ├─ posts/
        │       ╰─ <year>
        │               ╰─ /
@@ -393,7 +394,6 @@ fn blog() -> Result<(), Box<dyn Error>> {
        │                              ╰─ <post> [2]
        ├─ static/
        │        ╰─ <path:*> [5]
-       ├─ favicon.ico [6]
        ╰─ <page> [1]
     "###);
 
@@ -459,19 +459,19 @@ fn double_overlap() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ secret/
-       │        ├─ 978 [3]
-       │        ╰─ <id>
-       │              ╰─ /path [2]
        ├─ other/
        │       ├─ an_object/
        │       │           ╰─ <id> [5]
-       │       ├─ static/path [6]
        │       ├─ long/static/path/ [7]
+       │       ├─ static/path [6]
        │       ╰─ <object>
        │                 ╰─ /
        │                    ╰─ <id>
        │                          ╰─ / [4]
+       ├─ secret/
+       │        ├─ 978 [3]
+       │        ╰─ <id>
+       │              ╰─ /path [2]
        ╰─ <object>
                  ╰─ /
                     ╰─ <id> [1]
@@ -538,11 +538,11 @@ fn catchall_off_by_one() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo/
-       │     ╰─ <catchall:*> [1]
-       ╰─ bar [2]
-            ╰─ / [3]
-               ╰─ <catchall:*> [4]
+       ├─ bar [2]
+       │    ╰─ / [3]
+       │       ╰─ <catchall:*> [4]
+       ╰─ foo/
+             ╰─ <catchall:*> [1]
     "###);
 
     assert_router_matches!(router, {
@@ -592,13 +592,13 @@ fn overlap() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ / [8]
-       ├─ foo [1]
        ├─ ba
        │   ├─ r [2]
        │   ╰─ z [4]
        │      ╰─ / [5]
        │         ├─ x [6]
        │         ╰─ <xxx> [7]
+       ├─ foo [1]
        ├─ xxx/ [10]
        │     ╰─ <x:*> [9]
        ╰─ <bar:*> [3]
@@ -801,19 +801,19 @@ fn double_overlap_trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ secret/
-       │        ├─ 978/ [3]
-       │        ╰─ <id>
-       │              ╰─ /path [2]
        ├─ other/
        │       ├─ an_object/
        │       │           ╰─ <id> [5]
-       │       ├─ static/path [6]
        │       ├─ long/static/path/ [7]
+       │       ├─ static/path [6]
        │       ╰─ <object>
        │                 ╰─ /
        │                    ╰─ <id>
        │                          ╰─ / [4]
+       ├─ secret/
+       │        ├─ 978/ [3]
+       │        ╰─ <id>
+       │              ╰─ /path [2]
        ╰─ <object>
                  ╰─ /
                     ╰─ <id> [1]
@@ -926,20 +926,6 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ hi [1]
-       ├─ b/ [2]
-       ├─ s
-       │  ├─ earch/
-       │  │       ╰─ <query> [3]
-       │  ╰─ rc/
-       │       ╰─ <filepath:*> [5]
-       ├─ cmd/
-       │     ╰─ <tool>
-       │             ╰─ / [4]
-       ├─ x [6]
-       │  ╰─ /y [7]
-       ├─ y/ [8]
-       │   ╰─ z [9]
        ├─ 0/
        │   ╰─ <id> [10]
        │         ╰─ /1 [11]
@@ -948,8 +934,8 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
        │         ╰─ / [12]
        │            ╰─ 2 [13]
        ├─ a
-       │  ├─ a [14]
        │  ├─ / [15]
+       │  ├─ a [14]
        │  ├─ dmin [16]
        │  │     ╰─ /
        │  │        ├─ static [17]
@@ -957,28 +943,42 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
        │  │                    ╰─ /
        │  │                       ╰─ <page> [19]
        │  ╰─ pi/
-       │       ├─ hello/
-       │       │       ╰─ <name>
-       │       │               ╰─ /bar/ [27]
        │       ├─ ba
        │       │   ├─ r/
        │       │   │   ╰─ <name> [28]
        │       │   ╰─ z/foo [29]
        │       │          ╰─ /bar [30]
+       │       ├─ hello/
+       │       │       ╰─ <name>
+       │       │               ╰─ /bar/ [27]
        │       ╰─ <page>
        │               ╰─ /
        │                  ╰─ <name> [26]
+       ├─ b/ [2]
+       ├─ cmd/
+       │     ╰─ <tool>
+       │             ╰─ / [4]
        ├─ doc [20]
        │    ╰─ /rust
-       │           ├─ _faq.html [21]
-       │           ╰─ 1.26.html [22]
+       │           ├─ 1.26.html [22]
+       │           ╰─ _faq.html [21]
+       ├─ foo/
+       │     ╰─ <p> [31]
+       ├─ hi [1]
        ├─ no/
        │    ├─ a [23]
        │    │  ╰─ /b/
        │    │       ╰─ <other:*> [25]
        │    ╰─ b [24]
-       ╰─ foo/
-             ╰─ <p> [31]
+       ├─ s
+       │  ├─ earch/
+       │  │       ╰─ <query> [3]
+       │  ╰─ rc/
+       │       ╰─ <filepath:*> [5]
+       ├─ x [6]
+       │  ╰─ /y [7]
+       ╰─ y/ [8]
+           ╰─ z [9]
     "###);
 
     assert_router_matches!(router, {
@@ -1056,8 +1056,8 @@ fn root_trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo [1]
        ├─ bar [2]
+       ├─ foo [1]
        ╰─ <baz> [3]
     "###);
 
@@ -1262,16 +1262,16 @@ fn basic() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ├─ /
-    │  ├─ hi [1]
+    │  ├─ a [5]
+    │  │  ╰─ b [6]
     │  ├─ c [4]
     │  │  ╰─ o [3]
     │  │     ╰─ ntact [2]
-    │  ├─ a [5]
-    │  │  ╰─ b [6]
     │  ├─ doc/ [7]
     │  │     ╰─ rust
-    │  │           ├─ _faq.html [8]
-    │  │           ╰─ 1.26.html [9]
+    │  │           ├─ 1.26.html [9]
+    │  │           ╰─ _faq.html [8]
+    │  ├─ hi [1]
     │  ╰─ sd
     │      ├─ !here [12]
     │      ├─ $here [13]
@@ -1428,50 +1428,6 @@ fn wildcard() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ / [1]
-       ├─ c
-       │  ├─ md/
-       │  │    ├─ whoami [4]
-       │  │    │       ╰─ /root [5]
-       │  │    │              ╰─ / [6]
-       │  │    ├─ <tool>
-       │  │    │       ╰─ / [2]
-       │  │    ╰─ <tool2>
-       │  │             ╰─ /
-       │  │                ╰─ <sub> [3]
-       │  ╰─ 1/
-       │      ╰─ <dd>
-       │            ╰─ /e [27]
-       │                ╰─ 1 [28]
-       ├─ s
-       │  ├─ rc [7]
-       │  │   ╰─ / [8]
-       │  │      ╰─ <filepath:*> [9]
-       │  ├─ earch/ [10]
-       │  │       ├─ actix-we [12]
-       │  │       ├─ google [13]
-       │  │       ╰─ <query> [11]
-       │  ╰─ omething/
-       │             ├─ secondthing/test [37]
-       │             ╰─ <paramname>
-       │                          ╰─ /thirdthing [36]
-       ├─ user_
-       │      ╰─ <name> [14]
-       │              ╰─ /about [15]
-       ├─ files/
-       │       ╰─ <dir>
-       │              ╰─ /
-       │                 ╰─ <filepath:*> [16]
-       ├─ doc/ [17]
-       │     ╰─ rust
-       │           ├─ _faq.html [18]
-       │           ╰─ 1.26.html [19]
-       ├─ info/
-       │      ╰─ <user>
-       │              ╰─ /p
-       │                  ├─ ublic [20]
-       │                  ╰─ roject/
-       │                           ├─ rustlang [22]
-       │                           ╰─ <project> [21]
        ├─ a
        │  ├─ a/
        │  │   ╰─ <xx:*> [23]
@@ -1479,43 +1435,87 @@ fn wildcard() -> Result<(), Box<dyn Error>> {
        │      ├─ hello
        │      │      ╰─ <xx:*> [25]
        │      ╰─ <xx:*> [24]
+       ├─ c
+       │  ├─ 1/
+       │  │   ╰─ <dd>
+       │  │         ╰─ /e [27]
+       │  │             ╰─ 1 [28]
+       │  ╰─ md/
+       │       ├─ whoami [4]
+       │       │       ╰─ /root [5]
+       │       │              ╰─ / [6]
+       │       ├─ <tool>
+       │       │       ╰─ / [2]
+       │       ╰─ <tool2>
+       │                ╰─ /
+       │                   ╰─ <sub> [3]
+       ├─ doc/ [17]
+       │     ╰─ rust
+       │           ├─ 1.26.html [19]
+       │           ╰─ _faq.html [18]
+       ├─ files/
+       │       ╰─ <dir>
+       │              ╰─ /
+       │                 ╰─ <filepath:*> [16]
        ├─ get/
-       │     ├─ test/abc/ [34]
        │     ├─ abc [38]
        │     │    ╰─ /
        │     │       ├─ 123
-       │     │       │    ├─ ab
-       │     │       │    │   ├─ c [40]
-       │     │       │    │   │  ╰─ /
-       │     │       │    │   │     ├─ xxx8 [42]
-       │     │       │    │   │     │     ╰─ /
-       │     │       │    │   │     │        ├─ 1234 [44]
-       │     │       │    │   │     │        │     ╰─ /
-       │     │       │    │   │     │        │        ├─ ffas [46]
-       │     │       │    │   │     │        │        ├─ kkdd/
-       │     │       │    │   │     │        │        │      ├─ 12c [48]
-       │     │       │    │   │     │        │        │      ╰─ <param> [49]
-       │     │       │    │   │     │        │        ╰─ <param> [47]
-       │     │       │    │   │     │        ╰─ <param> [45]
-       │     │       │    │   │     ╰─ <param> [43]
-       │     │       │    │   ├─ d
-       │     │       │    │   │  ├─ /
-       │     │       │    │   │  │  ╰─ <param> [51]
-       │     │       │    │   │  ╰─ dd/
-       │     │       │    │   │       ╰─ <param> [52]
-       │     │       │    │   ├─ g/
-       │     │       │    │   │   ╰─ <param> [54]
-       │     │       │    │   ╰─ f
-       │     │       │    │      ├─ /
-       │     │       │    │      │  ╰─ <param> [55]
-       │     │       │    │      ╰─ ff/
-       │     │       │    │           ╰─ <param> [56]
-       │     │       │    ╰─ /
-       │     │       │       ╰─ <param> [53]
+       │     │       │    ├─ /
+       │     │       │    │  ╰─ <param> [53]
+       │     │       │    ╰─ ab
+       │     │       │        ├─ c [40]
+       │     │       │        │  ╰─ /
+       │     │       │        │     ├─ xxx8 [42]
+       │     │       │        │     │     ╰─ /
+       │     │       │        │     │        ├─ 1234 [44]
+       │     │       │        │     │        │     ╰─ /
+       │     │       │        │     │        │        ├─ ffas [46]
+       │     │       │        │     │        │        ├─ kkdd/
+       │     │       │        │     │        │        │      ├─ 12c [48]
+       │     │       │        │     │        │        │      ╰─ <param> [49]
+       │     │       │        │     │        │        ╰─ <param> [47]
+       │     │       │        │     │        ╰─ <param> [45]
+       │     │       │        │     ╰─ <param> [43]
+       │     │       │        ├─ d
+       │     │       │        │  ├─ /
+       │     │       │        │  │  ╰─ <param> [51]
+       │     │       │        │  ╰─ dd/
+       │     │       │        │       ╰─ <param> [52]
+       │     │       │        ├─ f
+       │     │       │        │  ├─ /
+       │     │       │        │  │  ╰─ <param> [55]
+       │     │       │        │  ╰─ ff/
+       │     │       │        │       ╰─ <param> [56]
+       │     │       │        ╰─ g/
+       │     │       │            ╰─ <param> [54]
        │     │       ╰─ <param> [41]
        │     │                ╰─ /test [50]
+       │     ├─ test/abc/ [34]
        │     ╰─ <param> [39]
        │              ╰─ /abc/ [35]
+       ├─ info/
+       │      ╰─ <user>
+       │              ╰─ /p
+       │                  ├─ roject/
+       │                  │        ├─ rustlang [22]
+       │                  │        ╰─ <project> [21]
+       │                  ╰─ ublic [20]
+       ├─ s
+       │  ├─ earch/ [10]
+       │  │       ├─ actix-we [12]
+       │  │       ├─ google [13]
+       │  │       ╰─ <query> [11]
+       │  ├─ omething/
+       │  │          ├─ secondthing/test [37]
+       │  │          ╰─ <paramname>
+       │  │                       ╰─ /thirdthing [36]
+       │  ╰─ rc [7]
+       │      ╰─ / [8]
+       │         ╰─ <filepath:*> [9]
+       ├─ user_
+       │      ╰─ <name> [14]
+       │              ╰─ /about [15]
        ╰─ <cc> [26]
              ╰─ /
                 ├─ cc [29]

--- a/tests/path_tree.rs
+++ b/tests/path_tree.rs
@@ -25,16 +25,16 @@ fn statics() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ / [0]
-       ├─ hi [1]
+       ├─ a [5]
+       │  ╰─ b [6]
        ├─ c [4]
        │  ╰─ o [3]
        │     ╰─ ntact [2]
-       ├─ a [5]
-       │  ╰─ b [6]
        ├─ doc/ [7]
        │     ╰─ go
-       │         ├─ _faq.html [8]
-       │         ╰─ 1.html [9]
+       │         ├─ 1.html [9]
+       │         ╰─ _faq.html [8]
+       ├─ hi [1]
        ╰─ �
             ├─ � [10]
             ╰─ � [11]
@@ -127,33 +127,33 @@ fn wildcards() -> Result<(), Box<dyn Error>> {
        │     ╰─ <tool>
        │             ╰─ / [2]
        │                ╰─ <sub> [1]
-       ├─ s
-       │  ├─ rc
-       │  │   ├─ /
-       │  │   │  ╰─ <filepath:*> [4]
-       │  │   ╰─ 1/ [5]
-       │  │       ╰─ <filepath:*> [6]
-       │  ╰─ earch/ [8]
-       │          ├─ invalid [10]
-       │          ╰─ <query> [9]
-       ├─ user_
-       │      ├─ x [13]
-       │      ╰─ <name> [11]
-       │              ╰─ /about [12]
+       ├─ doc/ [15]
+       │     ╰─ rust
+       │           ├─ 1.html [17]
+       │           ╰─ _faq.html [16]
        ├─ files/
        │       ╰─ <dir>
        │              ╰─ /
        │                 ╰─ <filepath:*> [14]
-       ├─ doc/ [15]
-       │     ╰─ rust
-       │           ├─ _faq.html [16]
-       │           ╰─ 1.html [17]
-       ╰─ info/
-              ╰─ <user>
-                      ╰─ /p
-                          ├─ ublic [18]
-                          ╰─ roject/
-                                   ╰─ <project> [19]
+       ├─ info/
+       │      ╰─ <user>
+       │              ╰─ /p
+       │                  ├─ roject/
+       │                  │        ╰─ <project> [19]
+       │                  ╰─ ublic [18]
+       ├─ s
+       │  ├─ earch/ [8]
+       │  │       ├─ invalid [10]
+       │  │       ╰─ <query> [9]
+       │  ╰─ rc
+       │      ├─ /
+       │      │  ╰─ <filepath:*> [4]
+       │      ╰─ 1/ [5]
+       │          ╰─ <filepath:*> [6]
+       ╰─ user_
+              ├─ x [13]
+              ╰─ <name> [11]
+                      ╰─ /about [12]
     "###);
 
     assert_router_matches!(router, {
@@ -307,8 +307,8 @@ fn static_and_named_parameter() -> Result<(), Box<dyn Error>> {
        ├─ a/
        │   ├─ b/c [/a/b/c]
        │   ╰─ c/
-       │       ├─ d [/a/c/d]
-       │       ╰─ a [/a/c/a]
+       │       ├─ a [/a/c/a]
+       │       ╰─ d [/a/c/d]
        ╰─ <id>
              ╰─ /c/e [/<id>/c/e]
     "###);
@@ -348,10 +348,10 @@ fn multi_named_parameters() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ <lang>
-       │       ╰─ /
-       │          ╰─ <keyword> [true]
-       ╰─ <id> [true]
+       ├─ <id> [true]
+       ╰─ <lang>
+               ╰─ /
+                  ╰─ <keyword> [true]
     "###);
 
     assert_router_matches!(router, {
@@ -523,8 +523,8 @@ fn static_and_catch_all_parameter() -> Result<(), Box<dyn Error>> {
     ╰─ /a/
          ├─ b/c [/a/b/c]
          ├─ c/
-         │   ├─ d [/a/c/d]
-         │   ╰─ a [/a/c/a]
+         │   ├─ a [/a/c/a]
+         │   ╰─ d [/a/c/d]
          ╰─ <c:*> [/a/*c]
     "###);
 
@@ -922,18 +922,18 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /api/v1/
               ╰─ <param>
-                       ├─ /
-                       │  ╰─ <param2> [3]
                        ├─ -
                        │  ╰─ <param2> [1]
-                       ├─ ~
-                       │  ╰─ <param2> [2]
                        ├─ .
                        │  ╰─ <param2> [4]
+                       ├─ /
+                       │  ╰─ <param2> [3]
+                       ├─ :
+                       │  ╰─ <param2> [6]
                        ├─ _
                        │  ╰─ <param2> [5]
-                       ╰─ :
-                          ╰─ <param2> [6]
+                       ╰─ ~
+                          ╰─ <param2> [2]
     "###);
 
     assert_router_matches!(router, {
@@ -1214,18 +1214,18 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ name
-       │     ╰─ <name> [1]
-       ├─ @
-       │  ╰─ <name> [2]
        ├─ -
        │  ╰─ <name> [3]
        ├─ .
        │  ╰─ <name> [4]
-       ├─ ~
-       │  ╰─ <name> [5]
+       ├─ @
+       │  ╰─ <name> [2]
        ├─ _
        │  ╰─ <name> [6]
+       ├─ name
+       │     ╰─ <name> [1]
+       ├─ ~
+       │  ╰─ <name> [5]
        ╰─ <name> [7]
     "###);
 
@@ -1481,41 +1481,41 @@ fn basic() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ / [0]
-       ├─ login [1]
-       ├─ s
-       │  ├─ ignup [2]
-       │  ╰─ ettings [3]
-       │           ╰─ /
-       │              ╰─ <page> [4]
-       ├─ public/
-       │        ╰─ <any:*> [7]
        ├─ api/
        │     ╰─ <plus:*> [13]
-       ├─ <user> [5]
-       │       ╰─ /
-       │          ╰─ <repo> [6]
-       ╰─ <org>
-              ╰─ /
-                 ╰─ <repo>
-                         ╰─ /
-                            ├─ releases/download/
-                            │                   ╰─ <tag>
-                            │                          ╰─ /
-                            │                             ╰─ <filename>
-                            │                                         ╰─ .
-                            │                                            ╰─ <ext> [8]
-                            ├─ tags/
-                            │      ╰─ <day>
-                            │             ╰─ -
-                            │                ╰─ <month>
-                            │                         ╰─ -
-                            │                            ╰─ <year> [9]
-                            ├─ actions/
-                            │         ╰─ <name>
-                            │                 ╰─ :
-                            │                    ╰─ <verb> [10]
-                            ├─ <page> [11]
-                            ╰─ <path:*> [12]
+       ├─ login [1]
+       ├─ public/
+       │        ╰─ <any:*> [7]
+       ├─ s
+       │  ├─ ettings [3]
+       │  │        ╰─ /
+       │  │           ╰─ <page> [4]
+       │  ╰─ ignup [2]
+       ├─ <org>
+       │      ╰─ /
+       │         ╰─ <repo>
+       │                 ╰─ /
+       │                    ├─ actions/
+       │                    │         ╰─ <name>
+       │                    │                 ╰─ :
+       │                    │                    ╰─ <verb> [10]
+       │                    ├─ releases/download/
+       │                    │                   ╰─ <tag>
+       │                    │                          ╰─ /
+       │                    │                             ╰─ <filename>
+       │                    │                                         ╰─ .
+       │                    │                                            ╰─ <ext> [8]
+       │                    ├─ tags/
+       │                    │      ╰─ <day>
+       │                    │             ╰─ -
+       │                    │                ╰─ <month>
+       │                    │                         ╰─ -
+       │                    │                            ╰─ <year> [9]
+       │                    ├─ <page> [11]
+       │                    ╰─ <path:*> [12]
+       ╰─ <user> [5]
+               ╰─ /
+                  ╰─ <repo> [6]
     "###);
 
     assert_router_matches!(router, {
@@ -1754,177 +1754,177 @@ fn github_tree() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ / [0]
-       ├─ a
-       │  ├─ pi [1]
-       │  ╰─ bout [2]
-       │        ╰─ /
-       │           ├─ careers [200]
-       │           ├─ press [201]
-       │           ╰─ diversity [202]
-       ├─ login [3]
-       ├─ s
-       │  ├─ ignup [4]
-       │  ├─ ponsors [10]
-       │  │        ╰─ /
-       │  │           ├─ explore [100]
-       │  │           ├─ accounts [101]
-       │  │           ╰─ <repo> [102]
-       │  │                   ╰─ /
-       │  │                      ├─ issues/
-       │  │                      │        ╰─ <path:*> [106]
-       │  │                      ├─ <user> [103]
-       │  │                      ├─ <plus:*>
-       │  │                      │         ╰─ /
-       │  │                      │            ├─ <file> [107]
-       │  │                      │            ╰─ <filename>
-       │  │                      │                        ╰─ .
-       │  │                      │                           ╰─ <ext> [108]
-       │  │                      ╰─ <plus:*> [104]
-       │  ╰─ e
-       │     ├─ arch [15]
-       │     ╰─ ttings [20]
-       │             ╰─ /
-       │                ├─ a
-       │                │  ├─ dmin [2000]
-       │                │  ├─ pp
-       │                │  │   ├─ earance [2001]
-       │                │  │   ╰─ s [2023]
-       │                │  ╰─ ccessibility [2002]
-       │                ├─ notifications [2003]
-       │                ├─ b
-       │                │  ├─ illing [2004]
-       │                │  │       ╰─ /plans [2005]
-       │                │  ╰─ locked_users [2009]
-       │                ├─ s
-       │                │  ├─ ecurity [2006]
-       │                │  │        ├─ _analysis [2018]
-       │                │  │        ╰─ -log [2021]
-       │                │  ╰─ ponsors-log [2022]
-       │                ├─ keys [2007]
-       │                ├─ organizations [2008]
-       │                ├─ in
-       │                │   ├─ teraction_limits [2010]
-       │                │   ╰─ stallations [2019]
-       │                ├─ co
-       │                │   ├─ de
-       │                │   │   ├─ _review_limits [2011]
-       │                │   │   ╰─ spaces [2013]
-       │                │   ╰─ pilot [2015]
-       │                ├─ re
-       │                │   ├─ p
-       │                │   │  ├─ ositories [2012]
-       │                │   │  ╰─ lies [2017]
-       │                │   ╰─ minders [2020]
-       │                ├─ de
-       │                │   ├─ leted_packages [2014]
-       │                │   ╰─ velopers [2024]
-       │                ├─ pages [2016]
-       │                ╰─ tokens [2025]
-       ├─ p
-       │  ├─ ricing [5]
-       │  ╰─ ulls [16]
-       ├─ features [6]
-       │         ╰─ /
-       │            ├─ actions [600]
-       │            ├─ packages [601]
-       │            ├─ security [602]
-       │            ├─ co
-       │            │   ├─ de
-       │            │   │   ├─ spaces [603]
-       │            │   │   ╰─ -review [605]
-       │            │   ╰─ pilot [604]
-       │            ├─ issues [606]
-       │            ╰─ discussions [607]
-       ├─ e
-       │  ├─ nterprise [7]
-       │  ╰─ xplore [19]
-       ├─ t
-       │  ├─ eam [8]
-       │  ├─ opics [12]
-       │  ╰─ rending [13]
-       ├─ c
-       │  ├─ ustomer-stories [9]
-       │  ╰─ ollections [14]
-       ├─ readme [11]
-       ├─ issues [17]
-       ├─ marketplace [18]
        ├─ 404 [21]
        ├─ 50
        │   ├─ 0 [22]
        │   ╰─ 3 [23]
+       ├─ a
+       │  ├─ bout [2]
+       │  │     ╰─ /
+       │  │        ├─ careers [200]
+       │  │        ├─ diversity [202]
+       │  │        ╰─ press [201]
+       │  ╰─ pi [1]
+       ├─ c
+       │  ├─ ollections [14]
+       │  ╰─ ustomer-stories [9]
+       ├─ e
+       │  ├─ nterprise [7]
+       │  ╰─ xplore [19]
+       ├─ features [6]
+       │         ╰─ /
+       │            ├─ actions [600]
+       │            ├─ co
+       │            │   ├─ de
+       │            │   │   ├─ -review [605]
+       │            │   │   ╰─ spaces [603]
+       │            │   ╰─ pilot [604]
+       │            ├─ discussions [607]
+       │            ├─ issues [606]
+       │            ├─ packages [601]
+       │            ╰─ security [602]
+       ├─ issues [17]
+       ├─ login [3]
+       ├─ marketplace [18]
        ├─ new [2504]
        │    ╰─ /import [2505]
        ├─ organizations/
        │               ├─ new [2506]
        │               ╰─ plan [2507]
+       ├─ p
+       │  ├─ ricing [5]
+       │  ╰─ ulls [16]
+       ├─ readme [11]
+       ├─ s
+       │  ├─ e
+       │  │  ├─ arch [15]
+       │  │  ╰─ ttings [20]
+       │  │          ╰─ /
+       │  │             ├─ a
+       │  │             │  ├─ ccessibility [2002]
+       │  │             │  ├─ dmin [2000]
+       │  │             │  ╰─ pp
+       │  │             │      ├─ earance [2001]
+       │  │             │      ╰─ s [2023]
+       │  │             ├─ b
+       │  │             │  ├─ illing [2004]
+       │  │             │  │       ╰─ /plans [2005]
+       │  │             │  ╰─ locked_users [2009]
+       │  │             ├─ co
+       │  │             │   ├─ de
+       │  │             │   │   ├─ _review_limits [2011]
+       │  │             │   │   ╰─ spaces [2013]
+       │  │             │   ╰─ pilot [2015]
+       │  │             ├─ de
+       │  │             │   ├─ leted_packages [2014]
+       │  │             │   ╰─ velopers [2024]
+       │  │             ├─ in
+       │  │             │   ├─ stallations [2019]
+       │  │             │   ╰─ teraction_limits [2010]
+       │  │             ├─ keys [2007]
+       │  │             ├─ notifications [2003]
+       │  │             ├─ organizations [2008]
+       │  │             ├─ pages [2016]
+       │  │             ├─ re
+       │  │             │   ├─ minders [2020]
+       │  │             │   ╰─ p
+       │  │             │      ├─ lies [2017]
+       │  │             │      ╰─ ositories [2012]
+       │  │             ├─ s
+       │  │             │  ├─ ecurity [2006]
+       │  │             │  │        ├─ -log [2021]
+       │  │             │  │        ╰─ _analysis [2018]
+       │  │             │  ╰─ ponsors-log [2022]
+       │  │             ╰─ tokens [2025]
+       │  ├─ ignup [4]
+       │  ╰─ ponsors [10]
+       │           ╰─ /
+       │              ├─ accounts [101]
+       │              ├─ explore [100]
+       │              ╰─ <repo> [102]
+       │                      ╰─ /
+       │                         ├─ issues/
+       │                         │        ╰─ <path:*> [106]
+       │                         ├─ <user> [103]
+       │                         ├─ <plus:*>
+       │                         │         ╰─ /
+       │                         │            ├─ <file> [107]
+       │                         │            ╰─ <filename>
+       │                         │                        ╰─ .
+       │                         │                           ╰─ <ext> [108]
+       │                         ╰─ <plus:*> [104]
+       ├─ t
+       │  ├─ eam [8]
+       │  ├─ opics [12]
+       │  ╰─ rending [13]
        ╰─ <org> [24]
               ╰─ /
                  ╰─ <repo> [2400]
                          ╰─ /
+                            ├─ actions [2440]
+                            │        ╰─ /
+                            │           ├─ runs/
+                            │           │      ╰─ <id> [2442]
+                            │           ╰─ workflows/
+                            │                       ╰─ <id> [2441]
+                            ├─ com
+                            │    ├─ m
+                            │    │  ├─ it/
+                            │    │  │    ╰─ <id> [2503]
+                            │    │  ╰─ unity [2490]
+                            │    ╰─ pare [2422]
+                            ├─ discussions [2430]
+                            │            ╰─ /
+                            │               ╰─ <id> [2431]
+                            ├─ graphs/co
+                            │          ├─ de-frequency [2482]
+                            │          ├─ mmit-activity [2481]
+                            │          ╰─ ntributors [2480]
                             ├─ issues [2410]
                             │       ╰─ /
                             │          ├─ new [2412]
                             │          ╰─ <id> [2411]
-                            ├─ pul
-                            │    ├─ l
-                            │    │  ├─ s [2420]
-                            │    │  ╰─ /
-                            │    │     ╰─ <id> [2421]
-                            │    ╰─ se [2470]
-                            ├─ com
-                            │    ├─ pare [2422]
-                            │    ╰─ m
-                            │       ├─ unity [2490]
-                            │       ╰─ it/
-                            │            ╰─ <id> [2503]
-                            ├─ discussions [2430]
-                            │            ╰─ /
-                            │               ╰─ <id> [2431]
-                            ├─ actions [2440]
-                            │        ╰─ /
-                            │           ├─ workflows/
-                            │           │           ╰─ <id> [2441]
-                            │           ╰─ runs/
-                            │                  ╰─ <id> [2442]
-                            ├─ w
-                            │  ├─ iki [2450]
-                            │  │    ╰─ /
-                            │  │       ╰─ <id> [2451]
-                            │  ╰─ atchers [2497]
-                            ├─ s
-                            │  ├─ ecurity [2460]
-                            │  │        ╰─ /
-                            │  │           ├─ policy [2461]
-                            │  │           ╰─ advisories [2462]
-                            │  ╰─ targazers [2495]
-                            │             ╰─ /yoou_know [2496]
-                            ├─ graphs/co
-                            │          ├─ ntributors [2480]
-                            │          ├─ mmit-activity [2481]
-                            │          ╰─ de-frequency [2482]
                             ├─ network [2491]
                             │        ╰─ /
                             │           ├─ dependen
                             │           │         ├─ cies [2492]
                             │           │         ╰─ ts [2493]
                             │           ╰─ members [2494]
+                            ├─ pul
+                            │    ├─ l
+                            │    │  ├─ /
+                            │    │  │  ╰─ <id> [2421]
+                            │    │  ╰─ s [2420]
+                            │    ╰─ se [2470]
                             ├─ releases [2498]
                             │         ╰─ /
-                            │            ├─ tag/
-                            │            │     ╰─ <id> [2499]
                             │            ├─ download/
                             │            │          ╰─ <tag>
                             │            │                 ╰─ /
                             │            │                    ╰─ <filename>
                             │            │                                ╰─ .
                             │            │                                   ╰─ <ext> [3002]
+                            │            ├─ tag/
+                            │            │     ╰─ <id> [2499]
                             │            ╰─ <path:*> [3001]
+                            ├─ s
+                            │  ├─ ecurity [2460]
+                            │  │        ╰─ /
+                            │  │           ├─ advisories [2462]
+                            │  │           ╰─ policy [2461]
+                            │  ╰─ targazers [2495]
+                            │             ╰─ /yoou_know [2496]
                             ├─ t
                             │  ├─ ags [2500]
                             │  │    ╰─ /
                             │  │       ╰─ <id> [2501]
                             │  ╰─ ree/
                             │        ╰─ <id> [2502]
+                            ├─ w
+                            │  ├─ atchers [2497]
+                            │  ╰─ iki [2450]
+                            │       ╰─ /
+                            │          ╰─ <id> [2451]
                             ╰─ <path:*> [3000]
     "###);
 


### PR DESCRIPTION
More boilerplate to implement the trait, but allows us to keep the node display feature, plus could be used for shorthand constraint usage.

Example of how this looks:

```rust
use wayfind::{assert_router_matches, node::Constraint, route::RouteBuilder, router::Router};

struct UserID;
impl Constraint for UserID {
    fn name() -> &'static str {
        "user_id"
    }

    fn check(segment: &str) -> bool {
        segment
            .chars()
            .all(|c| c.is_ascii_digit())
    }
}

struct UserName;
impl Constraint for UserName {
    fn name() -> &'static str {
        "user_name"
    }

    fn check(segment: &str) -> bool {
        segment.chars().all(char::is_alphabetic)
    }
}

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut router = Router::new();

    router.insert(
        RouteBuilder::new("/users/<id>")
            .constraint::<UserID>("id")
            .build()?,
        1,
    )?;

    router.insert(
        RouteBuilder::new("/users/<username>")
            .constraint::<UserName>("username")
            .build()?,
        2,
    )?;

    insta::assert_snapshot!(router, @r###"
    $
    ╰─ /users/
             ├─ <id> [1] (user_id)
             ╰─ <username> [2] (user_name)
    "###);

    assert_router_matches!(router, {
        "/users/123" => {
            path: "/users/<id>",
            value: 1,
            params: {
                "id" => "123"
            }
        }
        "/users/alice" => {
            path: "/users/<username>",
            value: 2,
            params: {
                "username" => "alice"
            }
        }
        "/users/123abc" => None
    });

    Ok(())
}
```

Part of me wishes the syntax was more like:

```rust 
let mut router = Router::new();
router.insert::<UserID>("/users/<id>", 1);
router.insert::<UserName>("/users/<username>", 2);
```

I suppose we could potentially look into supporting:

```rust 
let mut router = Router::new();
router.constraint::<UserID>();
router.constraint::<UserName>();

router.insert("/users/<id:user_id>", 1);
router.insert("/users/<username:user_name>", 2);
```

May need to tweak how wildcards work, then.