### PR TITLE
Use minimal profile for Rust toolchains

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,0 @@
-[store]
-dir = "target/nextest"
-
-[profile.default.junit]
-path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           cargo check --workspace
           cargo build --workspace
           cargo codspeed build
-          cargo llvm-cov nextest --all-targets --codecov --output-path target/nextest/default/codecov.json
+          cargo test --all-targets
 
       - name: Upload benchmark results to CodSpeed
         uses: CathalMullan/action@main
@@ -61,20 +61,6 @@ jobs:
           shell: nix develop .#ci --command bash {0}
           run: cargo codspeed run
           token: "${{ secrets.CODSPEED_TOKEN }}"
-
-      - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
-        with:
-          files: target/nextest/default/junit.xml
-          fail_ci_if_error: true
-          token: "${{ secrets.CODECOV_TOKEN }}"
-
-      - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: target/nextest/default/codecov.json
-          fail_ci_if_error: true
-          token: "${{ secrets.CODECOV_TOKEN }}"
 
       - name: Show SCCache stats
         if: always() && !cancelled()

--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,6 @@ target
 # Insta
 *.pending-snap
 
-# Tests
-junit.xml
-
-# Coverage
-lcov.info
-codecov.json
-
 # Fuzz
 corpus
 artifacts

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Crates.io](https://img.shields.io/crates/v/wayfind)](https://crates.io/crates/wayfind)
 [![Documentation](https://docs.rs/wayfind/badge.svg)](https://docs.rs/wayfind)
 [![CodSpeed Badge](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DuskSystems/wayfind)
-[![Codecov Badge](https://codecov.io/github/DuskSystems/wayfind/graph/badge.svg?token=QMSW55438K)](https://codecov.io/github/DuskSystems/wayfind)
 
 # `wayfind`
 

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,15 @@
       };
 
       rust-toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-      rust-toolchain-msrv = pkgs.rust-bin.stable."1.66.0".default;
-      rust-toolchain-nightly = pkgs.rust-bin.nightly."2024-07-25".default;
+      rust-toolchain-ci = pkgs.rust-bin.stable."1.80.1".minimal.override {
+        extensions = [
+          "clippy"
+          "llvm-tools"
+          "rustfmt"
+        ];
+      };
+      rust-toolchain-msrv = pkgs.rust-bin.stable."1.66.0".minimal;
+      rust-toolchain-nightly = pkgs.rust-bin.nightly."2024-07-25".minimal;
     in {
       devShells = {
         # nix develop
@@ -83,19 +90,14 @@
           RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
           CARGO_INCREMENTAL = "0";
 
-          buildInputs = with pkgs;
-            [
-              # Rust
-              rust-toolchain
-              sccache
-              cargo-codspeed
-              cargo-nextest
-            ]
-            ++ lib.optionals pkgs.stdenv.isLinux [
-              # Rust
-              # NOTE: https://github.com/NixOS/nixpkgs/pull/260725
-              cargo-llvm-cov
-            ];
+          buildInputs = with pkgs; [
+            # Rust
+            rust-toolchain-ci
+            sccache
+            cargo-codspeed
+            cargo-nextest
+            cargo-llvm-cov
+          ];
         };
 
         # nix develop .#msrv

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
       rust-toolchain-ci = pkgs.rust-bin.stable."1.80.1".minimal.override {
         extensions = [
           "clippy"
-          "llvm-tools"
           "rustfmt"
         ];
       };
@@ -59,28 +58,21 @@
           RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
           CARGO_INCREMENTAL = "0";
 
-          buildInputs = with pkgs;
-            [
-              # Rust
-              rust-toolchain
-              sccache
-              cargo-codspeed
-              cargo-insta
-              cargo-nextest
+          buildInputs = with pkgs; [
+            # Rust
+            rust-toolchain
+            sccache
+            cargo-codspeed
+            cargo-insta
 
-              # Benchmarking
-              gnuplot
+            # Benchmarking
+            gnuplot
 
-              # Nix
-              alejandra
-              statix
-              nil
-            ]
-            ++ lib.optionals pkgs.stdenv.isLinux [
-              # Rust
-              # NOTE: https://github.com/NixOS/nixpkgs/pull/260725
-              cargo-llvm-cov
-            ];
+            # Nix
+            alejandra
+            statix
+            nil
+          ];
         };
 
         # nix develop .#ci
@@ -95,8 +87,6 @@
             rust-toolchain-ci
             sccache
             cargo-codspeed
-            cargo-nextest
-            cargo-llvm-cov
           ];
         };
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,11 +2,4 @@
 [toolchain]
 channel = "1.80.1"
 profile = "minimal"
-components = [
-  "clippy",
-  "llvm-tools",
-  "rust-analyzer",
-  "rust-docs",
-  "rust-src",
-  "rustfmt",
-]
+components = ["clippy", "rust-analyzer", "rust-docs", "rust-src", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,12 +1,12 @@
+# https://rust-lang.github.io/rustup-components-history
 [toolchain]
 channel = "1.80.1"
-targets = ["wasm32-unknown-unknown"]
+profile = "minimal"
 components = [
-  "cargo",
-  "rustfmt",
   "clippy",
-  "rust-src",
-  "rust-std",
+  "llvm-tools",
   "rust-analyzer",
-  "llvm-tools-preview",
+  "rust-docs",
+  "rust-src",
+  "rustfmt",
 ]


### PR DESCRIPTION
Was able to reduce size of CI closure from 2.5G -> 1.8G.
Changing "pkgs.mkShell" -> "pkgs.mkShellNoCC" had no noticable change, so decided against it.

EDIT: Codecov has been very flaky for uploads. Considering removing it, or replacing it. Sad.

On the plus side, removing the coverage tooling results in a closure size of 1.4G.