### PR TITLE
Remove display trait bound for printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,25 +51,25 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // $
     // ╰─ /
-    //    ├─ pet [1]
+    //    ├─ pet [*]
     //    │    ╰─ /
     //    │       ├─ findBy
-    //    │       │       ├─ Status [2]
-    //    │       │       ╰─ Tags [3]
-    //    │       ╰─ {petId} [4]
-    //    │                ╰─ /uploadImage [5]
+    //    │       │       ├─ Status [*]
+    //    │       │       ╰─ Tags [*]
+    //    │       ╰─ {petId} [*]
+    //    │                ╰─ /uploadImage [*]
     //    ├─ store/
-    //    │       ├─ inventory [6]
-    //    │       ╰─ order [7]
+    //    │       ├─ inventory [*]
+    //    │       ╰─ order [*]
     //    │              ╰─ /
-    //    │                 ╰─ {orderId} [8]
-    //    ╰─ user [9]
+    //    │                 ╰─ {orderId} [*]
+    //    ╰─ user [*]
     //          ╰─ /
-    //             ├─ createWithList [10]
+    //             ├─ createWithList [*]
     //             ├─ log
-    //             │    ├─ in [11]
-    //             │    ╰─ out [12]
-    //             ╰─ {username} [13]
+    //             │    ├─ in [*]
+    //             │    ╰─ out [*]
+    //             ╰─ {username} [*]
 
     Ok(())
 }
@@ -107,20 +107,20 @@ fn main() -> Result<(), Box<dyn Error>> {
     router.insert("/v2/{*name:namespace}/referrers/{digest}", 7)?;
 
     // $
-    // ╰─ /v2 [1]
+    // ╰─ /v2 [*]
     //      ╰─ /
     //         ╰─ {*name:namespace}
     //                            ╰─ /
     //                               ├─ blobs/
-    //                               │       ├─ uploads [4]
+    //                               │       ├─ uploads [*]
     //                               │       │        ╰─ /
-    //                               │       │           ╰─ {reference} [5]
-    //                               │       ╰─ {digest} [2]
+    //                               │       │           ╰─ {reference} [*]
+    //                               │       ╰─ {digest} [*]
     //                               ├─ manifests/
-    //                               │           ╰─ {reference} [3]
+    //                               │           ╰─ {reference} [*]
     //                               ├─ referrers/
-    //                               │           ╰─ {digest} [7]
-    //                               ╰─ tags/list [6]
+    //                               │           ╰─ {digest} [*]
+    //                               ╰─ tags/list [*]
 
     Ok(())
 }

--- a/src/node/display.rs
+++ b/src/node/display.rs
@@ -2,10 +2,9 @@ use super::Node;
 use crate::node::NodeKind;
 use std::fmt::Display;
 
-impl<T: Display> Display for Node<T> {
-    #[allow(clippy::too_many_lines)]
+impl<T> Display for Node<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fn debug_node<T: Display>(
+        fn debug_node<T>(
             f: &mut std::fmt::Formatter,
             node: &Node<T>,
             padding: &str,
@@ -39,7 +38,7 @@ impl<T: Display> Display for Node<T> {
             let value = node
                 .data
                 .as_ref()
-                .map_or(String::new(), |node_data| format!(" [{}]", node_data.value));
+                .map_or(String::new(), |_node_data| " [*]".to_string());
 
             if is_root {
                 writeln!(f, "{key}")?;

--- a/tests/constraints.rs
+++ b/tests/constraints.rs
@@ -82,15 +82,15 @@ fn test_multiple_constraints() -> Result<(), Box<dyn Error>> {
        │  ├─ osts/
        │  │      ╰─ {year:even_year}
        │  │                        ╰─ /
-       │  │                           ╰─ {slug:valid_slug} [3]
+       │  │                           ╰─ {slug:valid_slug} [*]
        │  ╰─ rofile/
        │           ╰─ {username:length_3_to_10}
        │                                      ╰─ .
-       │                                         ╰─ {ext:png_or_jpg} [2]
+       │                                         ╰─ {ext:png_or_jpg} [*]
        ╰─ user/
               ╰─ {name:length_3_to_10}
                                      ╰─ /
-                                        ╰─ {id:year_1000_to_10000} [1]
+                                        ╰─ {id:year_1000_to_10000} [*]
     "###);
 
     assert_router_matches!(router, {

--- a/tests/matchit_delete.rs
+++ b/tests/matchit_delete.rs
@@ -27,38 +27,38 @@ fn normalized() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ s [8]
-       │  ╰─ /s [9]
+       ├─ s [*]
+       │  ╰─ /s [*]
        │      ╰─ /
-       │         ├─ s [10]
-       │         │  ╰─ /s [11]
+       │         ├─ s [*]
+       │         │  ╰─ /s [*]
        │         ├─ {s}
-       │         │    ╰─ /x [12]
+       │         │    ╰─ /x [*]
        │         ╰─ {y}
-       │              ╰─ /d [13]
+       │              ╰─ /d [*]
        ├─ x/
        │   ├─ {bar}
-       │   │      ╰─ /baz [1]
+       │   │      ╰─ /baz [*]
        │   ╰─ {foo}
-       │          ╰─ /bar [0]
+       │          ╰─ /bar [*]
        ├─ {bar}
        │      ╰─ /
        │         ╰─ {bay}
-       │                ╰─ /bay [7]
+       │                ╰─ /bay [*]
        ├─ {fod}
        │      ╰─ /
-       │         ├─ baz/bax/foo [5]
+       │         ├─ baz/bax/foo [*]
        │         ╰─ {baz}
        │                ╰─ /
        │                   ╰─ {bax}
-       │                          ╰─ /foo [4]
+       │                          ╰─ /foo [*]
        ╰─ {foo}
               ╰─ /
-                 ├─ baz/bax [6]
+                 ├─ baz/bax [*]
                  ├─ {bar}
-                 │      ╰─ /baz [3]
+                 │      ╰─ /baz [*]
                  ╰─ {baz}
-                        ╰─ /bax [2]
+                        ╰─ /bax [*]
     "###);
 
     assert_eq!(router.delete("/x/{foo}/bar"), Ok(()));
@@ -91,9 +91,9 @@ fn test() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /home [0]
+    ╰─ /home [*]
            ╰─ /
-              ╰─ {id} [1]
+              ╰─ {id} [*]
     "###);
 
     assert_eq!(router.delete("/home"), Ok(()));
@@ -121,18 +121,18 @@ fn blog() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ favicon.ico [5]
+       ├─ favicon.ico [*]
        ├─ posts/
        │       ╰─ {year}
        │               ╰─ /
-       │                  ├─ top [3]
+       │                  ├─ top [*]
        │                  ╰─ {month}
        │                           ╰─ /
-       │                              ├─ index [2]
-       │                              ╰─ {post} [1]
+       │                              ├─ index [*]
+       │                              ╰─ {post} [*]
        ├─ static/
-       │        ╰─ {*path} [4]
-       ╰─ {page} [0]
+       │        ╰─ {*path} [*]
+       ╰─ {page} [*]
     "###);
 
     assert_eq!(router.delete("/{page}"), Ok(()));
@@ -160,11 +160,11 @@ fn catchall() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ bar [1]
-       │    ╰─ / [2]
-       │       ╰─ {*catchall} [3]
+       ├─ bar [*]
+       │    ╰─ / [*]
+       │       ╰─ {*catchall} [*]
        ╰─ foo/
-             ╰─ {*catchall} [0]
+             ╰─ {*catchall} [*]
     "###);
 
     assert_eq!(router.delete("/foo/{*catchall}"), Ok(()));
@@ -173,9 +173,9 @@ fn catchall() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ╰─ bar [1]
+       ╰─ bar [*]
             ╰─ /
-               ╰─ {*catchall} [3]
+               ╰─ {*catchall} [*]
     "###);
 
     router.insert("/foo/{*catchall}", 4)?;
@@ -183,11 +183,11 @@ fn catchall() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ bar [1]
+       ├─ bar [*]
        │    ╰─ /
-       │       ╰─ {*catchall} [3]
+       │       ╰─ {*catchall} [*]
        ╰─ foo/
-             ╰─ {*catchall} [4]
+             ╰─ {*catchall} [*]
     "###);
 
     assert_eq!(router.delete("/bar/{*catchall}"), Ok(()));
@@ -195,9 +195,9 @@ fn catchall() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ bar [1]
+       ├─ bar [*]
        ╰─ foo/
-             ╰─ {*catchall} [4]
+             ╰─ {*catchall} [*]
     "###);
 
     Ok(())
@@ -219,20 +219,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [0]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [1]
-       ╰─ users [2]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/home"), Ok(()));
@@ -240,20 +240,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
+       │                           ╰─ {id} [*]
        ├─ home
        │     ╰─ /
-       │        ╰─ {id} [1]
-       ╰─ users [2]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/home", 9)?;
@@ -261,20 +261,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [1]
-       ╰─ users [2]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/home/{id}"), Ok(()));
@@ -282,18 +282,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
-       ╰─ users [2]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/home/{id}", 10)?;
@@ -301,20 +301,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [2]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/users"), Ok(()));
@@ -322,20 +322,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
+       │        ╰─ {id} [*]
        ╰─ users
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/users", 11)?;
@@ -343,20 +343,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [3]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/users/{id}"), Ok(()));
@@ -364,20 +364,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
                  ╰─ {id}
-                       ╰─ /posts [4]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/users/{id}", 12)?;
@@ -385,20 +385,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [4]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/users/{id}/posts"), Ok(()));
@@ -406,20 +406,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
+                 ╰─ {id} [*]
                        ╰─ /posts
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/users/{id}/posts", 13)?;
@@ -427,20 +427,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [5]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/users/{id}/posts/{post_id}"), Ok(()));
@@ -448,18 +448,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
     "###);
 
     router.insert("/users/{id}/posts/{post_id}", 14)?;
@@ -467,20 +467,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [6]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/articles"), Ok(()));
@@ -490,18 +490,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     ╰─ /
        ├─ articles
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/articles", 15)?;
@@ -509,20 +509,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [15]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [7]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/articles/{category}"), Ok(()));
@@ -530,20 +530,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [15]
+       ├─ articles [*]
        │         ╰─ /
        │            ╰─ {category}
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/articles/{category}", 16)?;
@@ -551,20 +551,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [15]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [16]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [8]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     assert_eq!(router.delete("/articles/{category}/{id}"), Ok(()));
@@ -572,18 +572,18 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [15]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [16]
-       ├─ home [9]
+       │            ╰─ {category} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     router.insert("/articles/{category}/{id}", 17)?;
@@ -591,20 +591,20 @@ fn overlapping_routes() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ articles [15]
+       ├─ articles [*]
        │         ╰─ /
-       │            ╰─ {category} [16]
+       │            ╰─ {category} [*]
        │                        ╰─ /
-       │                           ╰─ {id} [17]
-       ├─ home [9]
+       │                           ╰─ {id} [*]
+       ├─ home [*]
        │     ╰─ /
-       │        ╰─ {id} [10]
-       ╰─ users [11]
+       │        ╰─ {id} [*]
+       ╰─ users [*]
               ╰─ /
-                 ╰─ {id} [12]
-                       ╰─ /posts [13]
+                 ╰─ {id} [*]
+                       ╰─ /posts [*]
                                ╰─ /
-                                  ╰─ {post_id} [14]
+                                  ╰─ {post_id} [*]
     "###);
 
     Ok(())
@@ -619,9 +619,9 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo [1]
+       ├─ foo [*]
        ╰─ {home}
-               ╰─ / [0]
+               ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/"), Err(DeleteError::NotFound));
@@ -629,9 +629,9 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo [1]
+       ├─ foo [*]
        ╰─ {home}
-               ╰─ / [0]
+               ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/{home}"), Err(DeleteError::NotFound));
@@ -639,9 +639,9 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo [1]
+       ├─ foo [*]
        ╰─ {home}
-               ╰─ / [0]
+               ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/foo/"), Err(DeleteError::NotFound));
@@ -649,9 +649,9 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ foo [1]
+       ├─ foo [*]
        ╰─ {home}
-               ╰─ / [0]
+               ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/foo"), Ok(()));
@@ -660,7 +660,7 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ╰─ {home}
-               ╰─ / [0]
+               ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/{home}"), Err(DeleteError::NotFound));
@@ -669,7 +669,7 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ╰─ {home}
-               ╰─ / [0]
+               ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/{home}/"), Ok(()));
@@ -688,7 +688,7 @@ fn remove_root() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
+    ╰─ / [*]
     "###);
 
     assert_eq!(router.delete("/"), Ok(()));
@@ -716,17 +716,17 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
        │   ├─ r/
        │   │   ╰─ {user}
        │   │           ╰─ /
-       │   │              ╰─ {id} [2]
-       │   │                    ╰─ /baz [3]
+       │   │              ╰─ {id} [*]
+       │   │                    ╰─ /baz [*]
        │   ╰─ z/
        │       ╰─ {product}
        │                  ╰─ /
        │                     ╰─ {user}
        │                             ╰─ /
-       │                                ╰─ {id} [4]
+       │                                ╰─ {id} [*]
        ╰─ foo/
-             ╰─ {id} [0]
-                   ╰─ /bar [1]
+             ╰─ {id} [*]
+                   ╰─ /bar [*]
     "###);
 
     assert_eq!(router.delete("/foo/{a}"), Err(DeleteError::NotFound));
@@ -738,17 +738,17 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
        │   ├─ r/
        │   │   ╰─ {user}
        │   │           ╰─ /
-       │   │              ╰─ {id} [2]
-       │   │                    ╰─ /baz [3]
+       │   │              ╰─ {id} [*]
+       │   │                    ╰─ /baz [*]
        │   ╰─ z/
        │       ╰─ {product}
        │                  ╰─ /
        │                     ╰─ {user}
        │                             ╰─ /
-       │                                ╰─ {id} [4]
+       │                                ╰─ {id} [*]
        ╰─ foo/
-             ╰─ {id} [0]
-                   ╰─ /bar [1]
+             ╰─ {id} [*]
+                   ╰─ /bar [*]
     "###);
 
     assert_eq!(router.delete("/foo/{a}/bar"), Err(DeleteError::NotFound));
@@ -760,17 +760,17 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
        │   ├─ r/
        │   │   ╰─ {user}
        │   │           ╰─ /
-       │   │              ╰─ {id} [2]
-       │   │                    ╰─ /baz [3]
+       │   │              ╰─ {id} [*]
+       │   │                    ╰─ /baz [*]
        │   ╰─ z/
        │       ╰─ {product}
        │                  ╰─ /
        │                     ╰─ {user}
        │                             ╰─ /
-       │                                ╰─ {id} [4]
+       │                                ╰─ {id} [*]
        ╰─ foo/
-             ╰─ {id} [0]
-                   ╰─ /bar [1]
+             ╰─ {id} [*]
+                   ╰─ /bar [*]
     "###);
 
     assert_eq!(router.delete("/bar/{a}/{b}"), Err(DeleteError::NotFound));
@@ -782,17 +782,17 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
        │   ├─ r/
        │   │   ╰─ {user}
        │   │           ╰─ /
-       │   │              ╰─ {id} [2]
-       │   │                    ╰─ /baz [3]
+       │   │              ╰─ {id} [*]
+       │   │                    ╰─ /baz [*]
        │   ╰─ z/
        │       ╰─ {product}
        │                  ╰─ /
        │                     ╰─ {user}
        │                             ╰─ /
-       │                                ╰─ {id} [4]
+       │                                ╰─ {id} [*]
        ╰─ foo/
-             ╰─ {id} [0]
-                   ╰─ /bar [1]
+             ╰─ {id} [*]
+                   ╰─ /bar [*]
     "###);
 
     assert_eq!(
@@ -807,17 +807,17 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
        │   ├─ r/
        │   │   ╰─ {user}
        │   │           ╰─ /
-       │   │              ╰─ {id} [2]
-       │   │                    ╰─ /baz [3]
+       │   │              ╰─ {id} [*]
+       │   │                    ╰─ /baz [*]
        │   ╰─ z/
        │       ╰─ {product}
        │                  ╰─ /
        │                     ╰─ {user}
        │                             ╰─ /
-       │                                ╰─ {id} [4]
+       │                                ╰─ {id} [*]
        ╰─ foo/
-             ╰─ {id} [0]
-                   ╰─ /bar [1]
+             ╰─ {id} [*]
+                   ╰─ /bar [*]
     "###);
 
     assert_eq!(
@@ -832,17 +832,17 @@ fn check_escaped_params() -> Result<(), Box<dyn Error>> {
        │   ├─ r/
        │   │   ╰─ {user}
        │   │           ╰─ /
-       │   │              ╰─ {id} [2]
-       │   │                    ╰─ /baz [3]
+       │   │              ╰─ {id} [*]
+       │   │                    ╰─ /baz [*]
        │   ╰─ z/
        │       ╰─ {product}
        │                  ╰─ /
        │                     ╰─ {user}
        │                             ╰─ /
-       │                                ╰─ {id} [4]
+       │                                ╰─ {id} [*]
        ╰─ foo/
-             ╰─ {id} [0]
-                   ╰─ /bar [1]
+             ╰─ {id} [*]
+                   ╰─ /bar [*]
     "###);
 
     Ok(())

--- a/tests/matchit_matches.rs
+++ b/tests/matchit_matches.rs
@@ -19,8 +19,8 @@ fn partial_overlap() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /foo
-          ├─ /bar [Welcome!]
-          ╰─ _bar [Welcome!]
+          ├─ /bar [*]
+          ╰─ _bar [*]
     "###);
 
     assert_router_matches!(router, {
@@ -33,8 +33,8 @@ fn partial_overlap() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /foo [Welcome!]
-          ╰─ /bar [Welcome!]
+    ╰─ /foo [*]
+          ╰─ /bar [*]
     "###);
 
     assert_router_matches!(router, {
@@ -54,8 +54,8 @@ fn wildcard_overlap() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /path/
-            ├─ foo [foo]
-            ╰─ {*rest} [wildcard]
+            ├─ foo [*]
+            ╰─ {*rest} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -87,8 +87,8 @@ fn wildcard_overlap() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /path/
             ├─ foo/
-            │     ╰─ {arg} [foo]
-            ╰─ {*rest} [wildcard]
+            │     ╰─ {arg} [*]
+            ╰─ {*rest} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -126,15 +126,15 @@ fn overlapping_param_backtracking() -> Result<(), Box<dyn Error>> {
     router.insert("/secret/{id}/path", "secret with id and path")?;
 
     insta::assert_snapshot!(router, @r###"
-   $
-   ╰─ /
-      ├─ secret/
-      │        ╰─ {id}
-      │              ╰─ /path [secret with id and path]
-      ╰─ {object}
-                ╰─ /
-                   ╰─ {id} [object with id]
-   "###);
+    $
+    ╰─ /
+       ├─ secret/
+       │        ╰─ {id}
+       │              ╰─ /path [*]
+       ╰─ {object}
+                 ╰─ /
+                    ╰─ {id} [*]
+    "###);
 
     assert_router_matches!(router, {
         "/secret/978/path" => {
@@ -175,8 +175,8 @@ fn bare_catchall() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ├─ foo/
-    │     ╰─ {*bar} [2]
-    ╰─ {*foo} [1]
+    │     ╰─ {*bar} [*]
+    ╰─ {*foo} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -234,38 +234,38 @@ fn normalized() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ s [9]
-       │  ╰─ /s [10]
+       ├─ s [*]
+       │  ╰─ /s [*]
        │      ╰─ /
-       │         ├─ s [11]
-       │         │  ╰─ /s [12]
+       │         ├─ s [*]
+       │         │  ╰─ /s [*]
        │         ├─ {s}
-       │         │    ╰─ /x [13]
+       │         │    ╰─ /x [*]
        │         ╰─ {y}
-       │              ╰─ /d [14]
+       │              ╰─ /d [*]
        ├─ x/
        │   ├─ {bar}
-       │   │      ╰─ /baz [2]
+       │   │      ╰─ /baz [*]
        │   ╰─ {foo}
-       │          ╰─ /bar [1]
+       │          ╰─ /bar [*]
        ├─ {bar}
        │      ╰─ /
        │         ╰─ {bay}
-       │                ╰─ /bay [8]
+       │                ╰─ /bay [*]
        ├─ {fod}
        │      ╰─ /
-       │         ├─ baz/bax/foo [6]
+       │         ├─ baz/bax/foo [*]
        │         ╰─ {baz}
        │                ╰─ /
        │                   ╰─ {bax}
-       │                          ╰─ /foo [5]
+       │                          ╰─ /foo [*]
        ╰─ {foo}
               ╰─ /
-                 ├─ baz/bax [7]
+                 ├─ baz/bax [*]
                  ├─ {bar}
-                 │      ╰─ /baz [4]
+                 │      ╰─ /baz [*]
                  ╰─ {baz}
-                        ╰─ /bax [3]
+                        ╰─ /bax [*]
     "###);
 
     assert_router_matches!(router, {
@@ -386,18 +386,18 @@ fn blog() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ favicon.ico [6]
+       ├─ favicon.ico [*]
        ├─ posts/
        │       ╰─ {year}
        │               ╰─ /
-       │                  ├─ top [4]
+       │                  ├─ top [*]
        │                  ╰─ {month}
        │                           ╰─ /
-       │                              ├─ index [3]
-       │                              ╰─ {post} [2]
+       │                              ├─ index [*]
+       │                              ╰─ {post} [*]
        ├─ static/
-       │        ╰─ {*path} [5]
-       ╰─ {page} [1]
+       │        ╰─ {*path} [*]
+       ╰─ {page} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -460,25 +460,25 @@ fn double_overlap() -> Result<(), Box<dyn Error>> {
     router.insert("/other/long/static/path/", 7)?;
 
     insta::assert_snapshot!(router, @r###"
-   $
-   ╰─ /
-      ├─ other/
-      │       ├─ an_object/
-      │       │           ╰─ {id} [5]
-      │       ├─ long/static/path/ [7]
-      │       ├─ static/path [6]
-      │       ╰─ {object}
-      │                 ╰─ /
-      │                    ╰─ {id}
-      │                          ╰─ / [4]
-      ├─ secret/
-      │        ├─ 978 [3]
-      │        ╰─ {id}
-      │              ╰─ /path [2]
-      ╰─ {object}
-                ╰─ /
-                   ╰─ {id} [1]
-   "###);
+    $
+    ╰─ /
+       ├─ other/
+       │       ├─ an_object/
+       │       │           ╰─ {id} [*]
+       │       ├─ long/static/path/ [*]
+       │       ├─ static/path [*]
+       │       ╰─ {object}
+       │                 ╰─ /
+       │                    ╰─ {id}
+       │                          ╰─ / [*]
+       ├─ secret/
+       │        ├─ 978 [*]
+       │        ╰─ {id}
+       │              ╰─ /path [*]
+       ╰─ {object}
+                 ╰─ /
+                    ╰─ {id} [*]
+    "###);
 
     assert_router_matches!(router, {
         "/secret/978/path" => {
@@ -541,11 +541,11 @@ fn catchall_off_by_one() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ bar [2]
-       │    ╰─ / [3]
-       │       ╰─ {*catchall} [4]
+       ├─ bar [*]
+       │    ╰─ / [*]
+       │       ╰─ {*catchall} [*]
        ╰─ foo/
-             ╰─ {*catchall} [1]
+             ╰─ {*catchall} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -594,17 +594,17 @@ fn overlap() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [8]
+    ╰─ / [*]
        ├─ ba
-       │   ├─ r [2]
-       │   ╰─ z [4]
-       │      ╰─ / [5]
-       │         ├─ x [6]
-       │         ╰─ {xxx} [7]
-       ├─ foo [1]
-       ├─ xxx/ [10]
-       │     ╰─ {*x} [9]
-       ╰─ {*bar} [3]
+       │   ├─ r [*]
+       │   ╰─ z [*]
+       │      ╰─ / [*]
+       │         ├─ x [*]
+       │         ╰─ {xxx} [*]
+       ├─ foo [*]
+       ├─ xxx/ [*]
+       │     ╰─ {*x} [*]
+       ╰─ {*bar} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -671,14 +671,14 @@ fn missing_trailing_slash_param() -> Result<(), Box<dyn Error>> {
     router.insert("/foo/secret/978/", 3)?;
 
     insta::assert_snapshot!(router, @r###"
-   $
-   ╰─ /foo/
-          ├─ bar/baz [2]
-          ├─ secret/978/ [3]
-          ╰─ {object}
-                    ╰─ /
-                       ╰─ {id} [1]
-   "###);
+    $
+    ╰─ /foo/
+           ├─ bar/baz [*]
+           ├─ secret/978/ [*]
+           ╰─ {object}
+                     ╰─ /
+                        ╰─ {id} [*]
+    "###);
 
     assert_router_matches!(router, {
         "/foo/secret/978/" => {
@@ -706,14 +706,14 @@ fn extra_trailing_slash_param() -> Result<(), Box<dyn Error>> {
     router.insert("/foo/secret/978", 3)?;
 
     insta::assert_snapshot!(router, @r###"
-   $
-   ╰─ /foo/
-          ├─ bar/baz [2]
-          ├─ secret/978 [3]
-          ╰─ {object}
-                    ╰─ /
-                       ╰─ {id} [1]
-   "###);
+    $
+    ╰─ /foo/
+           ├─ bar/baz [*]
+           ├─ secret/978 [*]
+           ╰─ {object}
+                     ╰─ /
+                        ╰─ {id} [*]
+    "###);
 
     assert_router_matches!(router, {
         "/foo/secret/978/" => None
@@ -736,9 +736,9 @@ fn missing_trailing_slash_catch_all() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /foo/
-           ├─ bar/baz [2]
-           ├─ secret/978/ [3]
-           ╰─ {*bar} [1]
+           ├─ bar/baz [*]
+           ├─ secret/978/ [*]
+           ╰─ {*bar} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -768,9 +768,9 @@ fn extra_trailing_slash_catch_all() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /foo/
-           ├─ bar/baz [2]
-           ├─ secret/978 [3]
-           ╰─ {*bar} [1]
+           ├─ bar/baz [*]
+           ├─ secret/978 [*]
+           ╰─ {*bar} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -806,20 +806,20 @@ fn double_overlap_trailing_slash() -> Result<(), Box<dyn Error>> {
     ╰─ /
        ├─ other/
        │       ├─ an_object/
-       │       │           ╰─ {id} [5]
-       │       ├─ long/static/path/ [7]
-       │       ├─ static/path [6]
+       │       │           ╰─ {id} [*]
+       │       ├─ long/static/path/ [*]
+       │       ├─ static/path [*]
        │       ╰─ {object}
        │                 ╰─ /
        │                    ╰─ {id}
-       │                          ╰─ / [4]
+       │                          ╰─ / [*]
        ├─ secret/
-       │        ├─ 978/ [3]
+       │        ├─ 978/ [*]
        │        ╰─ {id}
-       │              ╰─ /path [2]
+       │              ╰─ /path [*]
        ╰─ {object}
                  ╰─ /
-                    ╰─ {id} [1]
+                    ╰─ {id} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -861,10 +861,10 @@ fn trailing_slash_overlap() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /foo/
-           ├─ bar/bar [3]
+           ├─ bar/bar [*]
            ╰─ {x}
-                ╰─ /baz [2]
-                      ╰─ / [1]
+                ╰─ /baz [*]
+                      ╰─ / [*]
     "###);
 
     assert_router_matches!(router, {
@@ -930,58 +930,58 @@ fn trailing_slash() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ├─ 0/
-       │   ╰─ {id} [10]
-       │         ╰─ /1 [11]
+       │   ╰─ {id} [*]
+       │         ╰─ /1 [*]
        ├─ 1/
        │   ╰─ {id}
-       │         ╰─ / [12]
-       │            ╰─ 2 [13]
+       │         ╰─ / [*]
+       │            ╰─ 2 [*]
        ├─ a
-       │  ├─ / [15]
-       │  ├─ a [14]
-       │  ├─ dmin [16]
+       │  ├─ / [*]
+       │  ├─ a [*]
+       │  ├─ dmin [*]
        │  │     ╰─ /
-       │  │        ├─ static [17]
-       │  │        ╰─ {category} [18]
+       │  │        ├─ static [*]
+       │  │        ╰─ {category} [*]
        │  │                    ╰─ /
-       │  │                       ╰─ {page} [19]
+       │  │                       ╰─ {page} [*]
        │  ╰─ pi/
        │       ├─ ba
        │       │   ├─ r/
-       │       │   │   ╰─ {name} [28]
-       │       │   ╰─ z/foo [29]
-       │       │          ╰─ /bar [30]
+       │       │   │   ╰─ {name} [*]
+       │       │   ╰─ z/foo [*]
+       │       │          ╰─ /bar [*]
        │       ├─ hello/
        │       │       ╰─ {name}
-       │       │               ╰─ /bar/ [27]
+       │       │               ╰─ /bar/ [*]
        │       ╰─ {page}
        │               ╰─ /
-       │                  ╰─ {name} [26]
-       ├─ b/ [2]
+       │                  ╰─ {name} [*]
+       ├─ b/ [*]
        ├─ cmd/
        │     ╰─ {tool}
-       │             ╰─ / [4]
-       ├─ doc [20]
+       │             ╰─ / [*]
+       ├─ doc [*]
        │    ╰─ /rust
-       │           ├─ 1.26.html [22]
-       │           ╰─ _faq.html [21]
+       │           ├─ 1.26.html [*]
+       │           ╰─ _faq.html [*]
        ├─ foo/
-       │     ╰─ {p} [31]
-       ├─ hi [1]
+       │     ╰─ {p} [*]
+       ├─ hi [*]
        ├─ no/
-       │    ├─ a [23]
+       │    ├─ a [*]
        │    │  ╰─ /b/
-       │    │       ╰─ {*other} [25]
-       │    ╰─ b [24]
+       │    │       ╰─ {*other} [*]
+       │    ╰─ b [*]
        ├─ s
        │  ├─ earch/
-       │  │       ╰─ {query} [3]
+       │  │       ╰─ {query} [*]
        │  ╰─ rc/
-       │       ╰─ {*filepath} [5]
-       ├─ x [6]
-       │  ╰─ /y [7]
-       ╰─ y/ [8]
-           ╰─ z [9]
+       │       ╰─ {*filepath} [*]
+       ├─ x [*]
+       │  ╰─ /y [*]
+       ╰─ y/ [*]
+           ╰─ z [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1036,10 +1036,10 @@ fn backtracking_trailing_slash() -> Result<(), Box<dyn Error>> {
     ╰─ /a/
          ├─ b/
          │   ╰─ {c}
-         │        ╰─ /d/ [2]
+         │        ╰─ /d/ [*]
          ╰─ {b}
               ╰─ /
-                 ╰─ {c} [1]
+                 ╰─ {c} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1059,9 +1059,9 @@ fn root_trailing_slash() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ bar [2]
-       ├─ foo [1]
-       ╰─ {baz} [3]
+       ├─ bar [*]
+       ├─ foo [*]
+       ╰─ {baz} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1081,8 +1081,8 @@ fn catchall_overlap() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /yyy
           ├─ /
-          │  ╰─ {*x} [1]
-          ╰─ {*x} [2]
+          │  ╰─ {*x} [*]
+          ╰─ {*x} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1265,29 +1265,29 @@ fn basic() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ├─ /
-    │  ├─ a [5]
-    │  │  ╰─ b [6]
-    │  ├─ c [4]
-    │  │  ╰─ o [3]
-    │  │     ╰─ ntact [2]
-    │  ├─ doc/ [7]
+    │  ├─ a [*]
+    │  │  ╰─ b [*]
+    │  ├─ c [*]
+    │  │  ╰─ o [*]
+    │  │     ╰─ ntact [*]
+    │  ├─ doc/ [*]
     │  │     ╰─ rust
-    │  │           ├─ 1.26.html [9]
-    │  │           ╰─ _faq.html [8]
-    │  ├─ hi [1]
+    │  │           ├─ 1.26.html [*]
+    │  │           ╰─ _faq.html [*]
+    │  ├─ hi [*]
     │  ╰─ sd
-    │      ├─ !here [12]
-    │      ├─ $here [13]
-    │      ├─ &here [14]
-    │      ├─ 'here [15]
-    │      ├─ (here [16]
-    │      ├─ )here [17]
-    │      ├─ +here [18]
-    │      ├─ ,here [19]
-    │      ├─ ;here [20]
-    │      ╰─ =here [21]
-    ├─ ʯ [10]
-    ╰─ β [11]
+    │      ├─ !here [*]
+    │      ├─ $here [*]
+    │      ├─ &here [*]
+    │      ├─ 'here [*]
+    │      ├─ (here [*]
+    │      ├─ )here [*]
+    │      ├─ +here [*]
+    │      ├─ ,here [*]
+    │      ├─ ;here [*]
+    │      ╰─ =here [*]
+    ├─ ʯ [*]
+    ╰─ β [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1430,109 +1430,109 @@ fn wildcard() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [1]
+    ╰─ / [*]
        ├─ a
        │  ├─ a/
-       │  │   ╰─ {*xx} [23]
+       │  │   ╰─ {*xx} [*]
        │  ╰─ b/
        │      ├─ hello
-       │      │      ╰─ {*xx} [25]
-       │      ╰─ {*xx} [24]
+       │      │      ╰─ {*xx} [*]
+       │      ╰─ {*xx} [*]
        ├─ c
        │  ├─ 1/
        │  │   ╰─ {dd}
-       │  │         ╰─ /e [27]
-       │  │             ╰─ 1 [28]
+       │  │         ╰─ /e [*]
+       │  │             ╰─ 1 [*]
        │  ╰─ md/
-       │       ├─ whoami [4]
-       │       │       ╰─ /root [5]
-       │       │              ╰─ / [6]
+       │       ├─ whoami [*]
+       │       │       ╰─ /root [*]
+       │       │              ╰─ / [*]
        │       ├─ {tool}
-       │       │       ╰─ / [2]
+       │       │       ╰─ / [*]
        │       ╰─ {tool2}
        │                ╰─ /
-       │                   ╰─ {sub} [3]
-       ├─ doc/ [17]
+       │                   ╰─ {sub} [*]
+       ├─ doc/ [*]
        │     ╰─ rust
-       │           ├─ 1.26.html [19]
-       │           ╰─ _faq.html [18]
+       │           ├─ 1.26.html [*]
+       │           ╰─ _faq.html [*]
        ├─ files/
        │       ╰─ {dir}
        │              ╰─ /
-       │                 ╰─ {*filepath} [16]
+       │                 ╰─ {*filepath} [*]
        ├─ get/
-       │     ├─ abc [38]
+       │     ├─ abc [*]
        │     │    ╰─ /
        │     │       ├─ 123
        │     │       │    ├─ /
-       │     │       │    │  ╰─ {param} [53]
+       │     │       │    │  ╰─ {param} [*]
        │     │       │    ╰─ ab
-       │     │       │        ├─ c [40]
+       │     │       │        ├─ c [*]
        │     │       │        │  ╰─ /
-       │     │       │        │     ├─ xxx8 [42]
+       │     │       │        │     ├─ xxx8 [*]
        │     │       │        │     │     ╰─ /
-       │     │       │        │     │        ├─ 1234 [44]
+       │     │       │        │     │        ├─ 1234 [*]
        │     │       │        │     │        │     ╰─ /
-       │     │       │        │     │        │        ├─ ffas [46]
+       │     │       │        │     │        │        ├─ ffas [*]
        │     │       │        │     │        │        ├─ kkdd/
-       │     │       │        │     │        │        │      ├─ 12c [48]
-       │     │       │        │     │        │        │      ╰─ {param} [49]
-       │     │       │        │     │        │        ╰─ {param} [47]
-       │     │       │        │     │        ╰─ {param} [45]
-       │     │       │        │     ╰─ {param} [43]
+       │     │       │        │     │        │        │      ├─ 12c [*]
+       │     │       │        │     │        │        │      ╰─ {param} [*]
+       │     │       │        │     │        │        ╰─ {param} [*]
+       │     │       │        │     │        ╰─ {param} [*]
+       │     │       │        │     ╰─ {param} [*]
        │     │       │        ├─ d
        │     │       │        │  ├─ /
-       │     │       │        │  │  ╰─ {param} [51]
+       │     │       │        │  │  ╰─ {param} [*]
        │     │       │        │  ╰─ dd/
-       │     │       │        │       ╰─ {param} [52]
+       │     │       │        │       ╰─ {param} [*]
        │     │       │        ├─ f
        │     │       │        │  ├─ /
-       │     │       │        │  │  ╰─ {param} [55]
+       │     │       │        │  │  ╰─ {param} [*]
        │     │       │        │  ╰─ ff/
-       │     │       │        │       ╰─ {param} [56]
+       │     │       │        │       ╰─ {param} [*]
        │     │       │        ╰─ g/
-       │     │       │            ╰─ {param} [54]
-       │     │       ╰─ {param} [41]
-       │     │                ╰─ /test [50]
-       │     ├─ test/abc/ [34]
-       │     ╰─ {param} [39]
-       │              ╰─ /abc/ [35]
+       │     │       │            ╰─ {param} [*]
+       │     │       ╰─ {param} [*]
+       │     │                ╰─ /test [*]
+       │     ├─ test/abc/ [*]
+       │     ╰─ {param} [*]
+       │              ╰─ /abc/ [*]
        ├─ info/
        │      ╰─ {user}
        │              ╰─ /p
        │                  ├─ roject/
-       │                  │        ├─ rustlang [22]
-       │                  │        ╰─ {project} [21]
-       │                  ╰─ ublic [20]
+       │                  │        ├─ rustlang [*]
+       │                  │        ╰─ {project} [*]
+       │                  ╰─ ublic [*]
        ├─ s
-       │  ├─ earch/ [10]
-       │  │       ├─ actix-we [12]
-       │  │       ├─ google [13]
-       │  │       ╰─ {query} [11]
+       │  ├─ earch/ [*]
+       │  │       ├─ actix-we [*]
+       │  │       ├─ google [*]
+       │  │       ╰─ {query} [*]
        │  ├─ omething/
-       │  │          ├─ secondthing/test [37]
+       │  │          ├─ secondthing/test [*]
        │  │          ╰─ {paramname}
-       │  │                       ╰─ /thirdthing [36]
-       │  ╰─ rc [7]
-       │      ╰─ / [8]
-       │         ╰─ {*filepath} [9]
+       │  │                       ╰─ /thirdthing [*]
+       │  ╰─ rc [*]
+       │      ╰─ / [*]
+       │         ╰─ {*filepath} [*]
        ├─ user_
-       │      ╰─ {name} [14]
-       │              ╰─ /about [15]
-       ╰─ {cc} [26]
+       │      ╰─ {name} [*]
+       │              ╰─ /about [*]
+       ╰─ {cc} [*]
              ╰─ /
-                ├─ cc [29]
+                ├─ cc [*]
                 ╰─ {dd}
                       ╰─ /
-                         ├─ ee [30]
+                         ├─ ee [*]
                          ╰─ {ee}
                                ╰─ /
-                                  ├─ ff [31]
+                                  ├─ ff [*]
                                   ╰─ {ff}
                                         ╰─ /
-                                           ├─ gg [32]
+                                           ├─ gg [*]
                                            ╰─ {gg}
-                                                 ╰─ /hh [33]
+                                                 ╰─ /hh [*]
     "###);
 
     assert_router_matches!(router, {

--- a/tests/path_tree.rs
+++ b/tests/path_tree.rs
@@ -27,20 +27,20 @@ fn statics() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
-       ├─ a [5]
-       │  ╰─ b [6]
-       ├─ c [4]
-       │  ╰─ o [3]
-       │     ╰─ ntact [2]
-       ├─ doc/ [7]
+    ╰─ / [*]
+       ├─ a [*]
+       │  ╰─ b [*]
+       ├─ c [*]
+       │  ╰─ o [*]
+       │     ╰─ ntact [*]
+       ├─ doc/ [*]
        │     ╰─ go
-       │         ├─ 1.html [9]
-       │         ╰─ _faq.html [8]
-       ├─ hi [1]
+       │         ├─ 1.html [*]
+       │         ╰─ _faq.html [*]
+       ├─ hi [*]
        ╰─ �
-            ├─ � [10]
-            ╰─ � [11]
+            ├─ � [*]
+            ╰─ � [*]
     "###);
 
     assert_router_matches!(router, {
@@ -124,39 +124,39 @@ fn wildcards() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
+    ╰─ / [*]
        ├─ cmd/
-       │     ├─ vet [3]
+       │     ├─ vet [*]
        │     ╰─ {tool}
-       │             ╰─ / [2]
-       │                ╰─ {sub} [1]
-       ├─ doc/ [15]
+       │             ╰─ / [*]
+       │                ╰─ {sub} [*]
+       ├─ doc/ [*]
        │     ╰─ rust
-       │           ├─ 1.html [17]
-       │           ╰─ _faq.html [16]
+       │           ├─ 1.html [*]
+       │           ╰─ _faq.html [*]
        ├─ files/
        │       ╰─ {dir}
        │              ╰─ /
-       │                 ╰─ {*filepath} [14]
+       │                 ╰─ {*filepath} [*]
        ├─ info/
        │      ╰─ {user}
        │              ╰─ /p
        │                  ├─ roject/
-       │                  │        ╰─ {project} [19]
-       │                  ╰─ ublic [18]
+       │                  │        ╰─ {project} [*]
+       │                  ╰─ ublic [*]
        ├─ s
-       │  ├─ earch/ [8]
-       │  │       ├─ invalid [10]
-       │  │       ╰─ {query} [9]
+       │  ├─ earch/ [*]
+       │  │       ├─ invalid [*]
+       │  │       ╰─ {query} [*]
        │  ╰─ rc
        │      ├─ /
-       │      │  ╰─ {*filepath} [4]
-       │      ╰─ 1/ [5]
-       │          ╰─ {*filepath} [6]
+       │      │  ╰─ {*filepath} [*]
+       │      ╰─ 1/ [*]
+       │          ╰─ {*filepath} [*]
        ╰─ user_
-              ├─ x [13]
-              ╰─ {name} [11]
-                      ╰─ /about [12]
+              ├─ x [*]
+              ╰─ {name} [*]
+                      ╰─ /about [*]
     "###);
 
     assert_router_matches!(router, {
@@ -245,7 +245,7 @@ fn single_named_parameter() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /users/
-             ╰─ {id} [0]
+             ╰─ {id} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -308,12 +308,12 @@ fn static_and_named_parameter() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ├─ a/
-       │   ├─ b/c [/a/b/c]
+       │   ├─ b/c [*]
        │   ╰─ c/
-       │       ├─ a [/a/c/a]
-       │       ╰─ d [/a/c/d]
+       │       ├─ a [*]
+       │       ╰─ d [*]
        ╰─ {id}
-             ╰─ /c/e [/{id}/c/e]
+             ╰─ /c/e [*]
     "###);
 
     assert_router_matches!(router, {
@@ -351,10 +351,10 @@ fn multi_named_parameters() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ├─ {id} [true]
+       ├─ {id} [*]
        ╰─ {lang}
                ╰─ /
-                  ╰─ {keyword} [true]
+                  ╰─ {keyword} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -390,7 +390,7 @@ fn catch_all_parameter() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /src/
-           ╰─ {*filepath} [* files]
+           ╰─ {*filepath} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -419,8 +419,8 @@ fn catch_all_parameter() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /src/ [dir]
-           ╰─ {*filepath} [* files]
+    ╰─ /src/ [*]
+           ╰─ {*filepath} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -524,11 +524,11 @@ fn static_and_catch_all_parameter() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ├─ b/c [/a/b/c]
+         ├─ b/c [*]
          ├─ c/
-         │   ├─ a [/a/c/a]
-         │   ╰─ d [/a/c/d]
-         ╰─ {*c} [/a/*c]
+         │   ├─ a [*]
+         │   ╰─ d [*]
+         ╰─ {*c} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -566,10 +566,10 @@ fn root_catch_all_parameter() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [1]
+    ╰─ / [*]
        ├─ users/
-       │       ╰─ {*wildcard} [3]
-       ╰─ {*wildcard} [2]
+       │       ╰─ {*wildcard} [*]
+       ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -604,7 +604,7 @@ fn root_catch_all_parameter_1() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ╰─ {*wildcard} [1]
+       ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -630,8 +630,8 @@ fn root_catch_all_parameter_1() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
-       ╰─ {*wildcard} [1]
+    ╰─ / [*]
+       ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -653,11 +653,11 @@ fn test_named_routes_with_non_ascii_paths() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
+    ╰─ / [*]
        ├─ matchme/
        │         ╰─ {slug}
-       │                 ╰─ / [2]
-       ╰─ {*wildcard} [1]
+       │                 ╰─ / [*]
+       ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -705,8 +705,8 @@ fn test_named_wildcard_collide() -> Result<(), Box<dyn Error>> {
     ╰─ /git/
            ├─ {org}
            │      ╰─ /
-           │         ╰─ {repo} [1]
-           ╰─ {*wildcard} [2]
+           │         ╰─ {repo} [*]
+           ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -740,7 +740,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     ╰─ /api/v1/
               ╰─ {param}
                        ╰─ /
-                          ╰─ {*wildcard} [1]
+                          ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -800,7 +800,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /v1/some/resource/name:customVerb [1]
+    ╰─ /v1/some/resource/name:customVerb [*]
     "###);
 
     assert_router_matches!(router, {
@@ -818,7 +818,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /v1/some/resource/
                         ╰─ {name}
-                                ╰─ :customVerb [1]
+                                ╰─ :customVerb [*]
     "###);
 
     assert_router_matches!(router, {
@@ -838,7 +838,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /api/v1/
-              ╰─ {*wildcard} [1]
+              ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -874,7 +874,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /api/v1/
-              ╰─ {param} [1]
+              ╰─ {param} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -904,17 +904,17 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     ╰─ /api/v1/
               ╰─ {param}
                        ├─ -
-                       │  ╰─ {param2} [1]
+                       │  ╰─ {param2} [*]
                        ├─ .
-                       │  ╰─ {param2} [4]
+                       │  ╰─ {param2} [*]
                        ├─ /
-                       │  ╰─ {param2} [3]
+                       │  ╰─ {param2} [*]
                        ├─ :
-                       │  ╰─ {param2} [6]
+                       │  ╰─ {param2} [*]
                        ├─ _
-                       │  ╰─ {param2} [5]
+                       │  ╰─ {param2} [*]
                        ╰─ ~
-                          ╰─ {param2} [2]
+                          ╰─ {param2} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -983,7 +983,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /api/v1/const [1]
+    ╰─ /api/v1/const [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1005,7 +1005,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /api/
            ╰─ {param}
-                    ╰─ /fixedEnd [1]
+                    ╰─ /fixedEnd [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1029,7 +1029,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
                                ╰─ /color:
                                         ╰─ {color}
                                                  ╰─ /size:
-                                                         ╰─ {size} [1]
+                                                         ╰─ {size} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1052,7 +1052,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /test
            ╰─ {sign}
-                   ╰─ {param} [1]
+                   ╰─ {param} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1073,18 +1073,18 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ├─ -
-       │  ╰─ {name} [3]
+       │  ╰─ {name} [*]
        ├─ .
-       │  ╰─ {name} [4]
+       │  ╰─ {name} [*]
        ├─ @
-       │  ╰─ {name} [2]
+       │  ╰─ {name} [*]
        ├─ _
-       │  ╰─ {name} [6]
+       │  ╰─ {name} [*]
        ├─ name
-       │     ╰─ {name} [1]
+       │     ╰─ {name} [*]
        ├─ ~
-       │  ╰─ {name} [5]
-       ╰─ {name} [7]
+       │  ╰─ {name} [*]
+       ╰─ {name} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1147,7 +1147,7 @@ fn match_params() -> Result<(), Box<dyn Error>> {
     ╰─ /api/v1/
               ╰─ {param}
                        ╰─ /abc/
-                              ╰─ {*wildcard} [1]
+                              ╰─ {*wildcard} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1277,17 +1277,17 @@ fn basic() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
+    ╰─ / [*]
        ├─ api/
-       │     ╰─ {*plus} [13]
-       ├─ login [1]
+       │     ╰─ {*plus} [*]
+       ├─ login [*]
        ├─ public/
-       │        ╰─ {*any} [7]
+       │        ╰─ {*any} [*]
        ├─ s
-       │  ├─ ettings [3]
+       │  ├─ ettings [*]
        │  │        ╰─ /
-       │  │           ╰─ {page} [4]
-       │  ╰─ ignup [2]
+       │  │           ╰─ {page} [*]
+       │  ╰─ ignup [*]
        ├─ {org}
        │      ╰─ /
        │         ╰─ {repo}
@@ -1295,24 +1295,24 @@ fn basic() -> Result<(), Box<dyn Error>> {
        │                    ├─ actions/
        │                    │         ╰─ {name}
        │                    │                 ╰─ :
-       │                    │                    ╰─ {verb} [10]
+       │                    │                    ╰─ {verb} [*]
        │                    ├─ releases/download/
        │                    │                   ╰─ {tag}
        │                    │                          ╰─ /
        │                    │                             ╰─ {filename}
        │                    │                                         ╰─ .
-       │                    │                                            ╰─ {ext} [8]
+       │                    │                                            ╰─ {ext} [*]
        │                    ├─ tags/
        │                    │      ╰─ {day}
        │                    │             ╰─ -
        │                    │                ╰─ {month}
        │                    │                         ╰─ -
-       │                    │                            ╰─ {year} [9]
-       │                    ├─ {page} [11]
-       │                    ╰─ {*path} [12]
-       ╰─ {user} [5]
+       │                    │                            ╰─ {year} [*]
+       │                    ├─ {page} [*]
+       │                    ╰─ {*path} [*]
+       ╰─ {user} [*]
                ╰─ /
-                  ╰─ {repo} [6]
+                  ╰─ {repo} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1553,179 +1553,179 @@ fn github_tree() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ / [0]
-       ├─ 404 [21]
+    ╰─ / [*]
+       ├─ 404 [*]
        ├─ 50
-       │   ├─ 0 [22]
-       │   ╰─ 3 [23]
+       │   ├─ 0 [*]
+       │   ╰─ 3 [*]
        ├─ a
-       │  ├─ bout [2]
+       │  ├─ bout [*]
        │  │     ╰─ /
-       │  │        ├─ careers [200]
-       │  │        ├─ diversity [202]
-       │  │        ╰─ press [201]
-       │  ╰─ pi [1]
+       │  │        ├─ careers [*]
+       │  │        ├─ diversity [*]
+       │  │        ╰─ press [*]
+       │  ╰─ pi [*]
        ├─ c
-       │  ├─ ollections [14]
-       │  ╰─ ustomer-stories [9]
+       │  ├─ ollections [*]
+       │  ╰─ ustomer-stories [*]
        ├─ e
-       │  ├─ nterprise [7]
-       │  ╰─ xplore [19]
-       ├─ features [6]
+       │  ├─ nterprise [*]
+       │  ╰─ xplore [*]
+       ├─ features [*]
        │         ╰─ /
-       │            ├─ actions [600]
+       │            ├─ actions [*]
        │            ├─ co
        │            │   ├─ de
-       │            │   │   ├─ -review [605]
-       │            │   │   ╰─ spaces [603]
-       │            │   ╰─ pilot [604]
-       │            ├─ discussions [607]
-       │            ├─ issues [606]
-       │            ├─ packages [601]
-       │            ╰─ security [602]
-       ├─ issues [17]
-       ├─ login [3]
-       ├─ marketplace [18]
-       ├─ new [2504]
-       │    ╰─ /import [2505]
+       │            │   │   ├─ -review [*]
+       │            │   │   ╰─ spaces [*]
+       │            │   ╰─ pilot [*]
+       │            ├─ discussions [*]
+       │            ├─ issues [*]
+       │            ├─ packages [*]
+       │            ╰─ security [*]
+       ├─ issues [*]
+       ├─ login [*]
+       ├─ marketplace [*]
+       ├─ new [*]
+       │    ╰─ /import [*]
        ├─ organizations/
-       │               ├─ new [2506]
-       │               ╰─ plan [2507]
+       │               ├─ new [*]
+       │               ╰─ plan [*]
        ├─ p
-       │  ├─ ricing [5]
-       │  ╰─ ulls [16]
-       ├─ readme [11]
+       │  ├─ ricing [*]
+       │  ╰─ ulls [*]
+       ├─ readme [*]
        ├─ s
        │  ├─ e
-       │  │  ├─ arch [15]
-       │  │  ╰─ ttings [20]
+       │  │  ├─ arch [*]
+       │  │  ╰─ ttings [*]
        │  │          ╰─ /
        │  │             ├─ a
-       │  │             │  ├─ ccessibility [2002]
-       │  │             │  ├─ dmin [2000]
+       │  │             │  ├─ ccessibility [*]
+       │  │             │  ├─ dmin [*]
        │  │             │  ╰─ pp
-       │  │             │      ├─ earance [2001]
-       │  │             │      ╰─ s [2023]
+       │  │             │      ├─ earance [*]
+       │  │             │      ╰─ s [*]
        │  │             ├─ b
-       │  │             │  ├─ illing [2004]
-       │  │             │  │       ╰─ /plans [2005]
-       │  │             │  ╰─ locked_users [2009]
+       │  │             │  ├─ illing [*]
+       │  │             │  │       ╰─ /plans [*]
+       │  │             │  ╰─ locked_users [*]
        │  │             ├─ co
        │  │             │   ├─ de
-       │  │             │   │   ├─ _review_limits [2011]
-       │  │             │   │   ╰─ spaces [2013]
-       │  │             │   ╰─ pilot [2015]
+       │  │             │   │   ├─ _review_limits [*]
+       │  │             │   │   ╰─ spaces [*]
+       │  │             │   ╰─ pilot [*]
        │  │             ├─ de
-       │  │             │   ├─ leted_packages [2014]
-       │  │             │   ╰─ velopers [2024]
+       │  │             │   ├─ leted_packages [*]
+       │  │             │   ╰─ velopers [*]
        │  │             ├─ in
-       │  │             │   ├─ stallations [2019]
-       │  │             │   ╰─ teraction_limits [2010]
-       │  │             ├─ keys [2007]
-       │  │             ├─ notifications [2003]
-       │  │             ├─ organizations [2008]
-       │  │             ├─ pages [2016]
+       │  │             │   ├─ stallations [*]
+       │  │             │   ╰─ teraction_limits [*]
+       │  │             ├─ keys [*]
+       │  │             ├─ notifications [*]
+       │  │             ├─ organizations [*]
+       │  │             ├─ pages [*]
        │  │             ├─ re
-       │  │             │   ├─ minders [2020]
+       │  │             │   ├─ minders [*]
        │  │             │   ╰─ p
-       │  │             │      ├─ lies [2017]
-       │  │             │      ╰─ ositories [2012]
+       │  │             │      ├─ lies [*]
+       │  │             │      ╰─ ositories [*]
        │  │             ├─ s
-       │  │             │  ├─ ecurity [2006]
-       │  │             │  │        ├─ -log [2021]
-       │  │             │  │        ╰─ _analysis [2018]
-       │  │             │  ╰─ ponsors-log [2022]
-       │  │             ╰─ tokens [2025]
-       │  ├─ ignup [4]
-       │  ╰─ ponsors [10]
+       │  │             │  ├─ ecurity [*]
+       │  │             │  │        ├─ -log [*]
+       │  │             │  │        ╰─ _analysis [*]
+       │  │             │  ╰─ ponsors-log [*]
+       │  │             ╰─ tokens [*]
+       │  ├─ ignup [*]
+       │  ╰─ ponsors [*]
        │           ╰─ /
-       │              ├─ accounts [101]
-       │              ├─ explore [100]
-       │              ╰─ {repo} [102]
+       │              ├─ accounts [*]
+       │              ├─ explore [*]
+       │              ╰─ {repo} [*]
        │                      ╰─ /
        │                         ├─ issues/
-       │                         │        ╰─ {*path} [106]
-       │                         ├─ {user} [103]
+       │                         │        ╰─ {*path} [*]
+       │                         ├─ {user} [*]
        │                         ├─ {*plus}
        │                         │        ╰─ /
-       │                         │           ├─ {file} [107]
+       │                         │           ├─ {file} [*]
        │                         │           ╰─ {filename}
        │                         │                       ╰─ .
-       │                         │                          ╰─ {ext} [108]
-       │                         ╰─ {*plus} [104]
+       │                         │                          ╰─ {ext} [*]
+       │                         ╰─ {*plus} [*]
        ├─ t
-       │  ├─ eam [8]
-       │  ├─ opics [12]
-       │  ╰─ rending [13]
-       ╰─ {org} [24]
+       │  ├─ eam [*]
+       │  ├─ opics [*]
+       │  ╰─ rending [*]
+       ╰─ {org} [*]
               ╰─ /
-                 ╰─ {repo} [2400]
+                 ╰─ {repo} [*]
                          ╰─ /
-                            ├─ actions [2440]
+                            ├─ actions [*]
                             │        ╰─ /
                             │           ├─ runs/
-                            │           │      ╰─ {id} [2442]
+                            │           │      ╰─ {id} [*]
                             │           ╰─ workflows/
-                            │                       ╰─ {id} [2441]
+                            │                       ╰─ {id} [*]
                             ├─ com
                             │    ├─ m
                             │    │  ├─ it/
-                            │    │  │    ╰─ {id} [2503]
-                            │    │  ╰─ unity [2490]
-                            │    ╰─ pare [2422]
-                            ├─ discussions [2430]
+                            │    │  │    ╰─ {id} [*]
+                            │    │  ╰─ unity [*]
+                            │    ╰─ pare [*]
+                            ├─ discussions [*]
                             │            ╰─ /
-                            │               ╰─ {id} [2431]
+                            │               ╰─ {id} [*]
                             ├─ graphs/co
-                            │          ├─ de-frequency [2482]
-                            │          ├─ mmit-activity [2481]
-                            │          ╰─ ntributors [2480]
-                            ├─ issues [2410]
+                            │          ├─ de-frequency [*]
+                            │          ├─ mmit-activity [*]
+                            │          ╰─ ntributors [*]
+                            ├─ issues [*]
                             │       ╰─ /
-                            │          ├─ new [2412]
-                            │          ╰─ {id} [2411]
-                            ├─ network [2491]
+                            │          ├─ new [*]
+                            │          ╰─ {id} [*]
+                            ├─ network [*]
                             │        ╰─ /
                             │           ├─ dependen
-                            │           │         ├─ cies [2492]
-                            │           │         ╰─ ts [2493]
-                            │           ╰─ members [2494]
+                            │           │         ├─ cies [*]
+                            │           │         ╰─ ts [*]
+                            │           ╰─ members [*]
                             ├─ pul
                             │    ├─ l
                             │    │  ├─ /
-                            │    │  │  ╰─ {id} [2421]
-                            │    │  ╰─ s [2420]
-                            │    ╰─ se [2470]
-                            ├─ releases [2498]
+                            │    │  │  ╰─ {id} [*]
+                            │    │  ╰─ s [*]
+                            │    ╰─ se [*]
+                            ├─ releases [*]
                             │         ╰─ /
                             │            ├─ download/
                             │            │          ╰─ {tag}
                             │            │                 ╰─ /
                             │            │                    ╰─ {filename}
                             │            │                                ╰─ .
-                            │            │                                   ╰─ {ext} [3002]
+                            │            │                                   ╰─ {ext} [*]
                             │            ├─ tag/
-                            │            │     ╰─ {id} [2499]
-                            │            ╰─ {*path} [3001]
+                            │            │     ╰─ {id} [*]
+                            │            ╰─ {*path} [*]
                             ├─ s
-                            │  ├─ ecurity [2460]
+                            │  ├─ ecurity [*]
                             │  │        ╰─ /
-                            │  │           ├─ advisories [2462]
-                            │  │           ╰─ policy [2461]
-                            │  ╰─ targazers [2495]
-                            │             ╰─ /yoou_know [2496]
+                            │  │           ├─ advisories [*]
+                            │  │           ╰─ policy [*]
+                            │  ╰─ targazers [*]
+                            │             ╰─ /yoou_know [*]
                             ├─ t
-                            │  ├─ ags [2500]
+                            │  ├─ ags [*]
                             │  │    ╰─ /
-                            │  │       ╰─ {id} [2501]
+                            │  │       ╰─ {id} [*]
                             │  ╰─ ree/
-                            │        ╰─ {id} [2502]
+                            │        ╰─ {id} [*]
                             ├─ w
-                            │  ├─ atchers [2497]
-                            │  ╰─ iki [2450]
+                            │  ├─ atchers [*]
+                            │  ╰─ iki [*]
                             │       ╰─ /
-                            │          ╰─ {id} [2451]
-                            ╰─ {*path} [3000]
+                            │          ╰─ {id} [*]
+                            ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1804,7 +1804,7 @@ fn test_dots_no_ext() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /
-       ╰─ {name} [1]
+       ╰─ {name} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -1859,8 +1859,8 @@ fn test_dots_ext_no_qualifier() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ╰─ {name}
-               ╰─ .js [2]
-                    ╰─ .gz [1]
+               ╰─ .js [*]
+                    ╰─ .gz [*]
     "###);
 
     assert_router_matches!(router, {

--- a/tests/poem.rs
+++ b/tests/poem.rs
@@ -37,9 +37,9 @@ fn test_insert_static_child_1() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /abc [1]
-          ╰─ def [2]
-               ╰─ gh [3]
+    ╰─ /abc [*]
+          ╰─ def [*]
+               ╰─ gh [*]
     "###);
 
     Ok(())
@@ -57,10 +57,10 @@ fn test_insert_static_child_2() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /ab
          ├─ 12
-         │   ├─ 34 [2]
-         │   ╰─ 56 [3]
-         │       ╰─ 78 [4]
-         ╰─ cd [1]
+         │   ├─ 34 [*]
+         │   ╰─ 56 [*]
+         │       ╰─ 78 [*]
+         ╰─ cd [*]
     "###);
 
     Ok(())
@@ -74,8 +74,8 @@ fn test_insert_static_child_3() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ /ab [2]
-         ╰─ c [1]
+    ╰─ /ab [*]
+         ╰─ c [*]
     "###);
 
     Ok(())
@@ -91,10 +91,10 @@ fn test_insert_param_child() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /abc/
-           ╰─ {p1} [1]
+           ╰─ {p1} [*]
                  ╰─ /
-                    ├─ p2 [2]
-                    ╰─ {p3} [3]
+                    ├─ p2 [*]
+                    ╰─ {p3} [*]
     "###);
 
     Ok(())
@@ -109,9 +109,9 @@ fn test_catch_all_child_1() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /ab
-         ├─ /de [2]
+         ├─ /de [*]
          ╰─ c/
-             ╰─ {*p1} [1]
+             ╰─ {*p1} [*]
     "###);
 
     Ok(())
@@ -124,7 +124,7 @@ fn test_catch_all_child_2() -> Result<(), Box<dyn Error>> {
 
     insta::assert_snapshot!(router, @r###"
     $
-    ╰─ {*p1} [1]
+    ╰─ {*p1} [*]
     "###);
 
     Ok(())
@@ -143,9 +143,9 @@ fn test_insert_regex_child() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /abc/
            ├─ def/
-           │     ╰─ {name:digit_string} [2]
+           │     ╰─ {name:digit_string} [*]
            ╰─ {name:digit_string}
-                                ╰─ /def [1]
+                                ╰─ /def [*]
     "###);
 
     Ok(())
@@ -197,29 +197,29 @@ fn test_matches() -> Result<(), Box<dyn Error>> {
     ╰─ /
        ├─ a
        │  ├─ /
-       │  │  ├─ b/c/d [7]
+       │  │  ├─ b/c/d [*]
        │  │  ╰─ {p1}
        │  │        ╰─ /
        │  │           ╰─ {p2}
-       │  │                 ╰─ /c [8]
+       │  │                 ╰─ /c [*]
        │  ╰─ b
-       │     ├─ /def [1]
+       │     ├─ /def [*]
        │     ╰─ c/
-       │         ├─ def [2]
+       │         ├─ def [*]
        │         │    ╰─ /
-       │         │       ╰─ {*p1} [6]
+       │         │       ╰─ {*p1} [*]
        │         ├─ {param:digit_string}
-       │         │                     ╰─ /def [10]
-       │         ╰─ {p1} [3]
+       │         │                     ╰─ /def [*]
+       │         ╰─ {p1} [*]
        │               ╰─ /
-       │                  ├─ def [4]
-       │                  ╰─ {p2} [5]
+       │                  ├─ def [*]
+       │                  ╰─ {p2} [*]
        ├─ kcd/
-       │     ╰─ {p1:digit_string} [11]
+       │     ╰─ {p1:digit_string} [*]
        ├─ {package}
        │          ╰─ /-/
-       │               ╰─ {package_tgz:ends_with_tgz} [12]
-       ╰─ {*p1} [9]
+       │               ╰─ {package_tgz:ends_with_tgz} [*]
+       ╰─ {*p1} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -313,8 +313,8 @@ fn test_match_priority() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ├─ bc [1]
-         ╰─ {*path} [2]
+         ├─ bc [*]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -332,9 +332,9 @@ fn test_match_priority() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ├─ bc [1]
-         ├─ {id} [3]
-         ╰─ {*path} [2]
+         ├─ bc [*]
+         ├─ {id} [*]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -353,10 +353,10 @@ fn test_match_priority() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ├─ bc [1]
-         ├─ {id:digit_string} [4]
-         ├─ {id} [3]
-         ╰─ {*path} [2]
+         ├─ bc [*]
+         ├─ {id:digit_string} [*]
+         ├─ {id} [*]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -374,11 +374,11 @@ fn test_match_priority() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ├─ 123 [5]
-         ├─ bc [1]
-         ├─ {id:digit_string} [4]
-         ├─ {id} [3]
-         ╰─ {*path} [2]
+         ├─ 123 [*]
+         ├─ bc [*]
+         ├─ {id:digit_string} [*]
+         ├─ {id} [*]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -399,7 +399,7 @@ fn test_catch_all_priority_in_sub_path() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ╰─ {*path} [1]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -418,8 +418,8 @@ fn test_catch_all_priority_in_sub_path() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /a/
          ├─ b/
-         │   ╰─ {*path} [2]
-         ╰─ {*path} [1]
+         │   ╰─ {*path} [*]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -439,9 +439,9 @@ fn test_catch_all_priority_in_sub_path() -> Result<(), Box<dyn Error>> {
     ╰─ /a/
          ├─ b/
          │   ├─ c/
-         │   │   ╰─ {*path} [3]
-         │   ╰─ {*path} [2]
-         ╰─ {*path} [1]
+         │   │   ╰─ {*path} [*]
+         │   ╰─ {*path} [*]
+         ╰─ {*path} [*]
     "###);
 
     assert_router_matches!(router, {
@@ -467,9 +467,9 @@ fn test_issue_275() -> Result<(), Box<dyn Error>> {
     $
     ╰─ /
        ├─ {id1}
-       │      ╰─ /a [1]
+       │      ╰─ /a [*]
        ╰─ {id2}
-              ╰─ /b [2]
+              ╰─ /b [*]
     "###);
 
     assert_router_matches!(router, {
@@ -500,7 +500,7 @@ fn test_percent_decoded() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(router, @r###"
     $
     ╰─ /a/
-         ╰─ {id} [1]
+         ╰─ {id} [*]
     "###);
 
     assert_router_matches!(router, {


### PR DESCRIPTION
Not thrilled with this, but better than not supporting any display for the most common use case (functions).