### PR TITLE
Document finished features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           cargo check --workspace
           cargo build --workspace
           cargo test --all-targets
+          cargo test --doc
 
       - name: Show SCCache stats
         if: always() && !cancelled()

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,6 @@ suspicious = { level = "deny", priority = -1 }
 # Personal Preferences
 module_name_repetitions = "allow"
 
-# FIXME: Strict
-missing_panics_doc = "allow"
-missing_errors_doc = "allow"
-
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3

--- a/benches/matchit_criterion.rs
+++ b/benches/matchit_criterion.rs
@@ -17,14 +17,14 @@ fn benchmark(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("matchit benchmarks");
 
     group.bench_function("matchit benchmarks/wayfind", |bencher| {
-        let mut router = wayfind::router::Router::new();
+        let mut router = wayfind::Router::new();
         for route in routes!(brackets) {
             router.insert(route, true).unwrap();
         }
 
         bencher.iter(|| {
             for route in black_box(paths()) {
-                let path = wayfind::path::Path::new(route).unwrap();
+                let path = wayfind::Path::new(route).unwrap();
                 let output = black_box(router.search(black_box(&path)).unwrap());
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());

--- a/benches/matchit_divan.rs
+++ b/benches/matchit_divan.rs
@@ -19,14 +19,14 @@ fn main() {
 
 #[divan::bench(name = "wayfind")]
 fn wayfind(bencher: divan::Bencher) {
-    let mut router = wayfind::router::Router::new();
+    let mut router = wayfind::Router::new();
     for route in routes!(brackets) {
         router.insert(route, true).unwrap();
     }
 
     bencher.bench(|| {
         for route in black_box(paths()) {
-            let path = wayfind::path::Path::new(route).unwrap();
+            let path = wayfind::Path::new(route).unwrap();
             let output = black_box(router.search(black_box(&path)).unwrap());
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());

--- a/benches/path_tree_criterion.rs
+++ b/benches/path_tree_criterion.rs
@@ -17,14 +17,14 @@ fn benchmark(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("path-tree benchmarks");
 
     group.bench_function("path-tree benchmarks/wayfind", |bencher| {
-        let mut router = wayfind::router::Router::new();
+        let mut router = wayfind::Router::new();
         for (index, route) in routes!(brackets).iter().enumerate() {
             router.insert(route, index).unwrap();
         }
 
         bencher.iter(|| {
             for route in black_box(paths()) {
-                let path = wayfind::path::Path::new(route).unwrap();
+                let path = wayfind::Path::new(route).unwrap();
                 let output = black_box(router.search(black_box(&path)).unwrap());
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());

--- a/benches/path_tree_divan.rs
+++ b/benches/path_tree_divan.rs
@@ -19,14 +19,14 @@ fn main() {
 
 #[divan::bench(name = "wayfind")]
 fn wayfind(bencher: divan::Bencher) {
-    let mut router = wayfind::router::Router::new();
+    let mut router = wayfind::Router::new();
     for (index, route) in routes!(brackets).iter().enumerate() {
         router.insert(route, index).unwrap();
     }
 
     bencher.bench(|| {
         for route in black_box(paths()) {
-            let path = wayfind::path::Path::new(route).unwrap();
+            let path = wayfind::Path::new(route).unwrap();
             let output = black_box(router.search(black_box(&path)).unwrap());
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());

--- a/examples/axum-fork/src/routing/path_router.rs
+++ b/examples/axum-fork/src/routing/path_router.rs
@@ -3,7 +3,7 @@ use axum_core::response::IntoResponse;
 use std::{borrow::Cow, collections::HashMap, convert::Infallible, fmt, sync::Arc};
 use tower_layer::Layer;
 use tower_service::Service;
-use wayfind::{errors::insert::InsertError, node::search::Match, path::Path, router::Router};
+use wayfind::{errors::InsertError, Match, Path, Router};
 
 use super::{
     future::RouteFuture, not_found::NotFound, strip_prefix::StripPrefix, url_params, Endpoint,

--- a/examples/axum-fork/src/routing/url_params.rs
+++ b/examples/axum-fork/src/routing/url_params.rs
@@ -1,7 +1,7 @@
 use crate::util::PercentDecodedStr;
 use http::Extensions;
 use std::sync::Arc;
-use wayfind::node::search::Parameter;
+use wayfind::Parameter;
 
 #[derive(Clone)]
 pub(crate) enum UrlParams {

--- a/examples/hyper/src/main.rs
+++ b/examples/hyper/src/main.rs
@@ -15,7 +15,7 @@ use std::{
     sync::Arc,
 };
 use tokio::{net::TcpListener, task::JoinSet};
-use wayfind::{node::search::Parameter, path::Path, router::Router};
+use wayfind::{Parameter, Path, Router};
 
 type BoxFuture<'a> = Pin<
     Box<

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
             })
             sccache
             cargo-insta
+            cargo-watch
 
             # Benchmarking
             cargo-codspeed

--- a/fuzz/fuzz_targets/insert.rs
+++ b/fuzz/fuzz_targets/insert.rs
@@ -3,7 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let mut router = wayfind::router::Router::new();
+    let mut router = wayfind::Router::new();
     if let Ok(route) = std::str::from_utf8(data) {
         let _ = router.insert(route, true);
     }

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -1,8 +1,34 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-pub trait Constraint {
+/// A constraint that can be used for custom path routing logic.
+///
+/// Must be a stateless, static check.
+/// In the future, we may support stateful constraints.
+///
+/// Constraints can be registered within a [`Router`](crate::Router) via the [`constraint`](crate::Router::constraint) function.
+///
+/// # Example
+///
+/// ```rust
+/// struct HelloConstraint;
+/// impl Constraint for HelloConstraint {
+///     fn name() -> &'static str {
+///         "hello"
+///     }
+///
+///     fn check(&self, segment: &str) -> bool {
+///         segment == "hello"
+///     }
+/// }
+/// ```
+pub trait Constraint: Send + Sync {
+    /// The name of the constraint.
+    ///
+    /// Must be unique within a given router.
+    /// Try and avoid generic constraint names like `id`.
     const NAME: &'static str;
 
+    /// Checks if a given segment matches this constraint.
     fn check(segment: &str) -> bool;
 }
 

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -10,13 +10,13 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 /// # Example
 ///
 /// ```rust
+/// use wayfind::Constraint;
+///
 /// struct HelloConstraint;
 /// impl Constraint for HelloConstraint {
-///     fn name() -> &'static str {
-///         "hello"
-///     }
+///     const NAME: &'static str = "hello";
 ///
-///     fn check(&self, segment: &str) -> bool {
+///     fn check(segment: &str) -> bool {
 ///         segment == "hello"
 ///     }
 /// }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,6 +1,8 @@
 use crate::errors::decode::DecodeError;
 use std::borrow::Cow;
 
+/// Try and percent-decode input bytes.
+/// Does not do any sort of normalization, simply decodes hex characters.
 pub fn percent_decode(input: &[u8]) -> Result<Cow<[u8]>, DecodeError> {
     if !input.contains(&b'%') {
         return Ok(Cow::Borrowed(input));

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,7 +1,7 @@
 use crate::errors::decode::DecodeError;
 use std::borrow::Cow;
 
-pub(crate) fn percent_decode(input: &[u8]) -> Result<Cow<[u8]>, DecodeError> {
+pub fn percent_decode(input: &[u8]) -> Result<Cow<[u8]>, DecodeError> {
     if !input.contains(&b'%') {
         return Ok(Cow::Borrowed(input));
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-//! Error types for `wayfind`.
+//! Error types for [`wayfind`](crate).
 //!
 //! All errors contain a user-friendly display method.
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,14 @@
-pub mod constraint;
-pub mod decode;
-pub mod delete;
-pub mod insert;
-pub mod route;
+pub(crate) mod constraint;
+pub use constraint::ConstraintError;
+
+pub(crate) mod decode;
+pub use decode::DecodeError;
+
+pub(crate) mod delete;
+pub use delete::DeleteError;
+
+pub(crate) mod insert;
+pub use insert::InsertError;
+
+pub(crate) mod route;
+pub use route::RouteError;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,7 @@
+//! Error types for `wayfind`.
+//!
+//! All errors contain a user-friendly display method.
+
 pub(crate) mod constraint;
 pub use constraint::ConstraintError;
 

--- a/src/errors/constraint.rs
+++ b/src/errors/constraint.rs
@@ -1,10 +1,43 @@
 use std::{error::Error, fmt::Display};
 
+/// Errors relating to constraints.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ConstraintError {
+    /// Constraint name is already in use.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::ConstraintError;
+    ///
+    /// let error = ConstraintError::DuplicateName {
+    ///     name: "my_constraint",
+    ///     existing_type: "my_crate::constraints::A",
+    ///     new_type: "my_crate::constraints::B",
+    /// };
+    ///
+    /// let display = "
+    /// duplicate constraint name
+    ///
+    /// The constraint name 'my_constraint' is already in use:
+    ///     - existing constraint type: 'my_crate::constraints::A'
+    ///     - new constraint type: 'my_crate::constraints::B'
+    ///
+    /// help: each constraint must have a unique name
+    ///
+    /// try:
+    ///     - Check if you have accidentally added the same constraint twice
+    ///     - Ensure different constraints have different names
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     DuplicateName {
+        /// The name of the constraint.
         name: &'static str,
+        /// The [`type_name`](std::any::type_name) of the already existing constraint.
         existing_type: &'static str,
+        /// The [`type_name`](std::any::type_name) of the attempted new constraint.
         new_type: &'static str,
     },
 }

--- a/src/errors/decode.rs
+++ b/src/errors/decode.rs
@@ -1,10 +1,39 @@
 use std::{error::Error, fmt::Display};
 
+/// Errors relating to percent-decoding failures.
 #[derive(Debug, PartialEq, Eq)]
 pub enum DecodeError {
+    /// Invalid percent-encoding sequence encountered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::DecodeError;
+    ///
+    /// let error = DecodeError::InvalidEncoding {
+    ///     input: "/hello%GGworld".to_string(),
+    ///     position: 6,
+    ///     character: [b'%', b'G', b'G'],
+    /// };
+    ///
+    /// let display = "
+    /// invalid percent-encoding
+    ///
+    ///    Input: /hello%GGworld
+    ///                 ^^^
+    ///
+    /// Expected: '%' followed by two hexadecimal digits (a-F, 0-9)
+    ///    Found: '%GG'
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     InvalidEncoding {
+        /// The unaltered input string.
         input: String,
+        /// The position in the input where the invalid encoding was found.
         position: usize,
+        /// The invalid character sequence.
         character: [u8; 3],
     },
 }

--- a/src/errors/delete.rs
+++ b/src/errors/delete.rs
@@ -1,10 +1,37 @@
 use super::route::RouteError;
 use std::{error::Error, fmt::Display};
 
+/// Errors relating to attempting to delete a route from a [`Router`](crate::Router).
 #[derive(Debug, PartialEq, Eq)]
 pub enum DeleteError {
+    /// A [`RouteError`] that occurred during the delete.
     RouteError(RouteError),
-    NotFound { path: String },
+
+    /// Path to be deleted was not found in the router.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::DeleteError;
+    ///
+    /// let error = DeleteError::NotFound {
+    ///     path: "/not_found".to_string(),
+    /// };
+    ///
+    /// let display = "
+    /// not found
+    ///
+    ///    Path: /not_found
+    ///
+    /// The specified path does not exist in the router
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    NotFound {
+        /// The path that was not found in the router.
+        path: String,
+    },
 }
 
 impl Error for DeleteError {}

--- a/src/errors/insert.rs
+++ b/src/errors/insert.rs
@@ -1,13 +1,94 @@
 use super::{decode::DecodeError, route::RouteError};
 use std::{error::Error, fmt::Display};
 
+/// Errors relating to attempting to insert a route into a [`Router`](crate::Router).
 #[derive(Debug, PartialEq, Eq)]
 pub enum InsertError {
+    /// A [`RouteError`] that occurred during the insert operation.
     RouteError(RouteError),
+
+    /// A [`DecodeError`] that occurred during the insert operation.
     DecodeError(DecodeError),
-    EncodedPath { input: String, decoded: String },
-    DuplicatePath { path: String },
-    UnknownConstraint { constraint: String },
+
+    /// The path provided was percent-encoded.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::InsertError;
+    ///
+    /// let error = InsertError::EncodedPath {
+    ///     input: "/hello%20world".to_string(),
+    ///     decoded: "/hello world".to_string(),
+    /// };
+    ///
+    /// let display = "
+    /// encoded path
+    ///
+    ///      Input: /hello%20world
+    ///    Decoded: /hello world
+    ///
+    /// The router expects paths to be in their decoded form
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    EncodedPath {
+        /// The original encoded input path.
+        input: String,
+        /// The decoded version of the path.
+        decoded: String,
+    },
+
+    /// The path being inserted already exists in the router.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::InsertError;
+    ///
+    /// let error = InsertError::DuplicatePath {
+    ///     path: "/existing/path".to_string(),
+    /// };
+    ///
+    /// let display = "
+    /// duplicate path
+    ///
+    ///    Path: /existing/path
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    DuplicatePath {
+        /// The path that already exists in the router.
+        path: String,
+    },
+
+    /// The constraint specified in the route is not recognized by the router.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::InsertError;
+    ///
+    /// let error = InsertError::UnknownConstraint {
+    ///     constraint: "unknown_constraint".to_string(),
+    /// };
+    ///
+    /// let display = "
+    /// unknown constraint
+    ///
+    ///    Constraint: unknown_constraint
+    ///
+    /// The router doesn't recognize this constraint
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    UnknownConstraint {
+        /// The name of the unrecognized constraint.
+        constraint: String,
+    },
 }
 
 impl Error for InsertError {}

--- a/src/errors/route.rs
+++ b/src/errors/route.rs
@@ -1,51 +1,222 @@
 use std::{error::Error, fmt::Display};
 
+/// Errors relating to malformed paths.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RouteError {
+    /// The path is empty.
     EmptyPath,
 
-    // Braces
+    /// Empty braces were found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::EmptyBraces {
+    ///     path: "/{}".to_string(),
+    ///     position: 1,
+    /// };
+    ///
+    /// let display = "
+    /// empty braces
+    ///
+    ///    Path: /{}
+    ///           ^^
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     EmptyBraces {
+        /// The path containing empty braces.
         path: String,
+        /// The position where the empty braces were found.
         position: usize,
     },
 
-    // Escaping
+    /// An unescaped brace was found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::UnescapedBrace {
+    ///     path: "/{".to_string(),
+    ///     position: 1,
+    /// };
+    ///
+    /// let display = "
+    /// unescaped brace
+    ///
+    ///    Path: /{
+    ///           ^
+    ///
+    /// tip: Use '{{' and '}}' to represent literal '{' and '}' characters in the path
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     UnescapedBrace {
+        /// The path constaining an unescaped brace.
         path: String,
+        /// The position of the unescaped brace.
         position: usize,
     },
 
-    // Parameter
+    /// An empty parameter name was found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::EmptyParameter {
+    ///     path: "/{:}".to_string(),
+    ///     start: 1,
+    ///     length: 3,
+    /// };
+    ///
+    /// let display = "
+    /// empty parameter name
+    ///
+    ///    Path: /{:}
+    ///           ^^^
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     EmptyParameter {
+        /// The path constaining an empty parameter.
         path: String,
+        /// The position of the empty parameter.
         start: usize,
+        /// The length of the empty parameter (including braces).
         length: usize,
     },
 
+    /// An invalid parameter name was found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::InvalidParameter {
+    ///     path: "/{a/b}".to_string(),
+    ///     start: 1,
+    ///     length: 5,
+    /// };
+    ///
+    /// let display = "
+    /// invalid parameter name
+    ///
+    ///    Path: /{a/b}
+    ///           ^^^^^
+    ///
+    /// tip: Parameter names must not contain the characters: ':', '*', '?', '{', '}', '/'
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     InvalidParameter {
+        /// The path constaining an invalid parameter.
         path: String,
+        /// The position of the invalid parameter.
         start: usize,
+        /// The length of the invalid parameter (including braces).
         length: usize,
     },
 
-    // Wildcard
+    /// An empty wildcard parameter was found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::EmptyWildcard {
+    ///     path: "/{*}".to_string(),
+    ///     start: 1,
+    ///     length: 3,
+    /// };
+    ///
+    /// let display = "
+    /// empty wildcard name
+    ///
+    ///    Path: /{*}
+    ///           ^^^
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     EmptyWildcard {
+        /// The path constaining an empty wildcard parameter.
         path: String,
+        /// The position of the empty wildcard parameter.
         start: usize,
+        /// The length of the empty wildcard parameter (including braces).
         length: usize,
     },
 
-    // Constraint
+    /// An empty constraint name was found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::EmptyConstraint {
+    ///     path: "/{a:}".to_string(),
+    ///     position: 3,
+    /// };
+    ///
+    /// let display = "
+    /// empty constraint name
+    ///
+    ///    Path: /{a:}
+    ///             ^
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     EmptyConstraint {
+        /// The path constaining an empty constraint.
         path: String,
-        start: usize,
-        length: usize,
+        /// The position of the empty constraint delimiter (i.e. ':').
+        position: usize,
     },
 
+    /// An invalid constraint name was found in the path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wayfind::errors::RouteError;
+    ///
+    /// let error = RouteError::InvalidConstraint {
+    ///     path: "/{a:b/c}".to_string(),
+    ///     start: 4,
+    ///     length: 3,
+    /// };
+    ///
+    /// let display = "
+    /// invalid constraint name
+    ///
+    ///    Path: /{a:b/c}
+    ///              ^^^
+    ///
+    /// tip: Constraint names must not contain the characters: ':', '*', '?', '{', '}', '/'
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
     InvalidConstraint {
+        /// The path constaining an invalid constraint.
         path: String,
+        /// The position of the invalid constraint.
         start: usize,
+        /// The length of the invalid constraint.
         length: usize,
     },
 }
@@ -133,12 +304,8 @@ tip: Parameter names must not contain the characters: ':', '*', '?', '{{', '}}',
             }
 
             // Constraint
-            Self::EmptyConstraint {
-                path,
-                start,
-                length,
-            } => {
-                let arrow = " ".repeat(*start) + &"^".repeat(*length);
+            Self::EmptyConstraint { path, position } => {
+                let arrow = " ".repeat(*position) + "^";
                 write!(
                     f,
                     r#"empty constraint name

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,19 @@
-//! TODO
+//! Hello world!
 
-pub mod constraints;
-pub mod decode;
+pub(crate) mod constraints;
+pub use constraints::Constraint;
+
+pub(crate) mod decode;
+
 pub mod errors;
-pub mod node;
-pub mod parts;
-pub mod path;
-pub mod router;
+
+pub(crate) mod node;
+pub use node::search::{Match, Parameter};
+
+pub(crate) mod parts;
+
+pub(crate) mod path;
+pub use path::Path;
+
+pub(crate) mod router;
+pub use router::Router;

--- a/src/node.rs
+++ b/src/node.rs
@@ -5,27 +5,47 @@ pub mod display;
 pub mod insert;
 pub mod search;
 
+/// A node in the router tree structure.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NodeKind {
+    /// The root node of the tree.
+    /// Must only be used in the router new method.
     Root,
+
+    /// A static node with a fixed path segment.
     Static,
+
+    /// A dynamic node that can match any bytes, excluding b'/'.
     Dynamic,
+
+    /// A wildcard node that can match any bytes, including b'/'.
     Wildcard,
+
+    /// An end wildcard node that matches the whole remaining path.
+    /// Must only exist at the end of a tree.
     EndWildcard,
 }
 
+/// Holds data associated with a given node.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NodeData<T> {
+    /// The full path from the root to this node.
     pub path: Arc<str>,
+    /// The value associated with this node.
     pub value: T,
 }
 
+/// Represents a node in the tree structure.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Node<T> {
     pub kind: NodeKind,
 
+    /// The prefix may either be the static bytes of a path, or the name of a variable.
     pub prefix: Vec<u8>,
+    /// Optional data associated with this node.
+    /// The presense of this data is needed to successfully match a route.
     pub data: Option<NodeData<T>>,
+    /// An optional check to run, to restrict routing to this node.
     pub constraint: Option<Vec<u8>>,
 
     pub static_children: Vec<Node<T>>,
@@ -33,6 +53,7 @@ pub struct Node<T> {
     pub wildcard_children: Vec<Node<T>>,
     pub end_wildcard_children: Vec<Node<T>>,
 
-    // TODO: Come up with a better names.
+    /// A flag indicating whether this node's dynamic children can be matched quickly.
+    /// This allows us to traverse the next section of the path by segment, rather than byte-by-byte, when matching.
     pub quick_dynamic: bool,
 }

--- a/src/node/delete.rs
+++ b/src/node/delete.rs
@@ -5,6 +5,12 @@ use crate::{
 };
 
 impl<T> Node<T> {
+    /// Deletes a route from the node tree.
+    ///
+    /// This method recursively traverses the tree to find and remove the specified route.
+    /// Logic should match that used by the insert method.
+    ///
+    /// If the route is found and deleted, we re-optimize the tree structure.
     pub fn delete(&mut self, parts: &mut Parts) -> Result<(), DeleteError> {
         if let Some(segment) = parts.pop() {
             let result = match segment {
@@ -143,6 +149,9 @@ impl<T> Node<T> {
         Ok(())
     }
 
+    /// Re-optimize the tree after a deletion.
+    ///
+    /// This method removes empty children, then updates quick search flags.
     fn optimize(&mut self) {
         self.static_children.retain_mut(|child| {
             child.optimize();

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -118,7 +118,7 @@ impl<'a> Parts<'a> {
                 return Err(RouteError::EmptyWildcard {
                     path: String::from_utf8_lossy(path).to_string(),
                     start: cursor,
-                    length: end - cursor + 1,
+                    length: end - start + 2,
                 });
             }
 
@@ -132,6 +132,7 @@ impl<'a> Parts<'a> {
         if name.iter().any(|&c| INVALID_PARAM_CHARS.contains(&c)) {
             return Err(RouteError::InvalidParameter {
                 path: String::from_utf8_lossy(path).to_string(),
+                name: String::from_utf8_lossy(name).to_string(),
                 start: start - 1,
                 length: end - start + 2,
             });
@@ -141,15 +142,17 @@ impl<'a> Parts<'a> {
             if constraint.is_empty() {
                 return Err(RouteError::EmptyConstraint {
                     path: String::from_utf8_lossy(path).to_string(),
-                    position: colon.unwrap() + 2,
+                    start: start - 1,
+                    length: end - start + 2,
                 });
             }
 
             if constraint.iter().any(|&c| INVALID_PARAM_CHARS.contains(&c)) {
                 return Err(RouteError::InvalidConstraint {
                     path: String::from_utf8_lossy(path).to_string(),
-                    start: colon.unwrap() + 3,
-                    length: constraint.len(),
+                    name: String::from_utf8_lossy(constraint).to_string(),
+                    start: start - 1,
+                    length: end - start + 2,
                 });
             }
         }
@@ -378,7 +381,7 @@ mod tests {
         empty constraint name
 
            Path: /{name:}
-                       ^
+                  ^^^^^^^
         "###);
     }
 
@@ -419,7 +422,7 @@ mod tests {
         invalid constraint name
 
            Path: /{name:with:colon}
-                        ^^^^^^^^^^
+                  ^^^^^^^^^^^^^^^^^
 
         tip: Constraint names must not contain the characters: ':', '*', '?', '{', '}', '/'
         "###);

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -141,15 +141,14 @@ impl<'a> Parts<'a> {
             if constraint.is_empty() {
                 return Err(RouteError::EmptyConstraint {
                     path: String::from_utf8_lossy(path).to_string(),
-                    start: start + name.len() + 1,
-                    length: 1,
+                    position: colon.unwrap() + 2,
                 });
             }
 
             if constraint.iter().any(|&c| INVALID_PARAM_CHARS.contains(&c)) {
                 return Err(RouteError::InvalidConstraint {
                     path: String::from_utf8_lossy(path).to_string(),
-                    start: start + name.len() + 1,
+                    start: colon.unwrap() + 3,
                     length: constraint.len(),
                 });
             }
@@ -379,7 +378,7 @@ mod tests {
         empty constraint name
 
            Path: /{name:}
-                        ^
+                       ^
         "###);
     }
 

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -1,9 +1,10 @@
 use crate::errors::route::RouteError;
 use std::fmt::Debug;
 
-// NOTE: '?' is reserved for potential future use.
+/// Characters that are not allowed in parameter names or constraints.
 const INVALID_PARAM_CHARS: [u8; 6] = [b':', b'*', b'?', b'{', b'}', b'/'];
 
+/// A parsed section of a path.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Part {
     Static {
@@ -21,9 +22,14 @@ pub enum Part {
     },
 }
 
+/// A parsed path.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Parts<'a> {
+    /// The original path.
     pub path: &'a [u8],
+
+    /// The parsed parts of the path, in reverse order.
+    /// We may want these to simply be indicies of the original path in the future, to reduce allocations.
     pub inner: Vec<Part>,
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -23,7 +23,9 @@ impl<'path> Path<'path> {
     /// ## Valid
     ///
     /// ```rust
-    /// let path = wayfind::Path::new("/hello%20world").unwrap();
+    /// use wayfind::Path;
+    ///
+    /// let path = Path::new("/hello%20world").unwrap();
     /// assert_eq!(path.raw_bytes(), b"/hello%20world");
     /// assert_eq!(path.decoded_bytes(), b"/hello world");
     /// ```
@@ -31,18 +33,14 @@ impl<'path> Path<'path> {
     /// ## Invalid
     ///
     /// ```rust
-    /// let path = wayfind::Path::new("/hello%GGworld").unwrap_err();
-    /// let error = "
-    /// invalid percent-encoding
+    /// use wayfind::{Path, errors::DecodeError};
     ///
-    ///    Input: /hello%GGworld
-    ///                 ^^^
-    ///
-    /// Expected: '%' followed by two hexadecimal digits (a-F, 0-9)
-    ///    Found: '%GG'
-    /// ";
-    ///
-    /// assert_eq!(path.to_string(), error.trim());
+    /// let path = Path::new("/hello%GGworld").unwrap_err();
+    /// assert_eq!(path, DecodeError::InvalidEncoding {
+    ///     input: "/hello%GGworld".to_string(),
+    ///     position: 6,
+    ///     character: [b'%', b'G', b'G'],
+    /// });
     /// ```
     pub fn new(path: &'path str) -> Result<Self, DecodeError> {
         Ok(Self {

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,39 +1,65 @@
 use crate::{decode::percent_decode, errors::decode::DecodeError};
 use std::borrow::Cow;
 
+/// [`Path`] stores the URI data to be used to search for a matching route in a [`Router`](crate::Router).
 #[derive(Debug)]
 pub struct Path<'path> {
+    /// Original, unaltered path bytes.
+    raw: &'path [u8],
+
+    /// Percent-decoded path bytes.
     decoded: Cow<'path, [u8]>,
 }
 
 impl<'path> Path<'path> {
+    /// Creates a new [`Path`] instance from a URI path string.
+    ///
+    /// # Errors
+    ///
+    /// Will error if the path fails percent-decoding.
+    ///
+    /// # Examples
+    ///
+    /// ## Valid
+    ///
+    /// ```rust
+    /// let path = wayfind::Path::new("/hello%20world").unwrap();
+    /// assert_eq!(path.raw_bytes(), b"/hello%20world");
+    /// assert_eq!(path.decoded_bytes(), b"/hello world");
+    /// ```
+    ///
+    /// ## Invalid
+    ///
+    /// ```rust
+    /// let path = wayfind::Path::new("/hello%GGworld").unwrap_err();
+    /// let error = "
+    /// invalid percent-encoding
+    ///
+    ///    Input: /hello%GGworld
+    ///                 ^^^
+    ///
+    /// Expected: '%' followed by two hexadecimal digits (a-F, 0-9)
+    ///    Found: '%GG'
+    /// ";
+    ///
+    /// assert_eq!(path.to_string(), error.trim());
+    /// ```
     pub fn new(path: &'path str) -> Result<Self, DecodeError> {
         Ok(Self {
+            raw: path.as_bytes(),
             decoded: percent_decode(path.as_bytes())?,
         })
     }
 
+    /// Returns a reference to the original path bytes.
+    #[must_use]
+    pub const fn raw_bytes(&'path self) -> &'path [u8] {
+        self.raw
+    }
+
+    /// Returns a reference to the percent-decoded path bytes.
     #[must_use]
     pub fn decoded_bytes(&'path self) -> &'path [u8] {
         &self.decoded
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_path_invalid_encoding() {
-        let error = Path::new("/hello%20world%GG").unwrap_err();
-        insta::assert_snapshot!(error, @r###"
-        invalid percent-encoding
-
-           Input: /hello%20world%GG
-                                ^^^
-
-        Expected: '%' followed by two hexadecimal digits (a-F, 0-9)
-           Found: '%GG'
-        "###);
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -28,6 +28,7 @@ pub struct Router<T> {
 
 impl<T> Router<T> {
     #[must_use]
+    #[allow(clippy::missing_panics_doc)]
     pub fn new() -> Self {
         let mut router = Self {
             root: Node {
@@ -68,6 +69,7 @@ impl<T> Router<T> {
         router
     }
 
+    #[allow(clippy::missing_errors_doc)]
     pub fn constraint<C: Constraint>(&mut self) -> Result<(), ConstraintError> {
         match self.constraints.entry(C::NAME.as_bytes().to_vec()) {
             Entry::Vacant(entry) => {
@@ -86,6 +88,7 @@ impl<T> Router<T> {
         }
     }
 
+    #[allow(clippy::missing_errors_doc)]
     pub fn insert(&mut self, route: &str, value: T) -> Result<(), InsertError> {
         let path = Path::new(route)?;
         if route.as_bytes() != path.decoded_bytes() {
@@ -119,6 +122,7 @@ impl<T> Router<T> {
         self.root.insert(&mut parts, NodeData { path, value })
     }
 
+    #[allow(clippy::missing_errors_doc)]
     pub fn delete(&mut self, route: &str) -> Result<(), DeleteError> {
         let mut parts = Parts::new(route.as_bytes())?;
         self.root.delete(&mut parts)

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -44,6 +44,7 @@ pub struct ExpectedMatch<'k, 'v, T> {
     pub params: Vec<Parameter<'k, 'v>>,
 }
 
+#[allow(clippy::missing_panics_doc)]
 pub fn assert_router_match<'a, T: PartialEq + Debug>(
     router: &'a Router<T>,
     input: &'a str,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,9 +1,5 @@
 use std::{fmt::Debug, sync::Arc};
-use wayfind::{
-    node::search::{Match, Parameter},
-    path::Path,
-    router::Router,
-};
+use wayfind::{Match, Parameter, Path, Router};
 
 #[macro_export]
 macro_rules! assert_router_matches {
@@ -28,7 +24,7 @@ macro_rules! assert_router_matches {
             value: $value,
             params: vec![
                 $(
-                    $( wayfind::node::search::Parameter {
+                    $( wayfind::Parameter {
                         key: $param_key,
                         value: $param_value,
                     } ),+

--- a/tests/constraints.rs
+++ b/tests/constraints.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_lines)]
 
 use std::error::Error;
-use wayfind::{constraints::Constraint, router::Router};
+use wayfind::{Constraint, Router};
 
 #[path = "./common.rs"]
 mod common;

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use wayfind::router::Router;
+use wayfind::Router;
 
 #[path = "./common.rs"]
 mod common;

--- a/tests/matchit_delete.rs
+++ b/tests/matchit_delete.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 
 use std::error::Error;
-use wayfind::router::Router;
+use wayfind::Router;
 
 #[test]
 fn normalized() -> Result<(), Box<dyn Error>> {

--- a/tests/matchit_matches.rs
+++ b/tests/matchit_matches.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::too_many_lines)]
 
 use std::error::Error;
-use wayfind::router::Router;
+use wayfind::Router;
 
 #[path = "./common.rs"]
 mod common;

--- a/tests/path_tree.rs
+++ b/tests/path_tree.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::too_many_lines)]
 
 use std::error::Error;
-use wayfind::router::Router;
+use wayfind::Router;
 
 #[path = "./common.rs"]
 mod common;

--- a/tests/poem.rs
+++ b/tests/poem.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::too_many_lines)]
 
 use std::error::Error;
-use wayfind::{constraints::Constraint, router::Router};
+use wayfind::{Constraint, Router};
 
 #[path = "./common.rs"]
 mod common;

--- a/tests/uncommon.rs
+++ b/tests/uncommon.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_lines)]
 
 use std::error::Error;
-use wayfind::router::Router;
+use wayfind::Router;
 
 #[path = "./common.rs"]
 mod common;


### PR DESCRIPTION
Both internal and public API needs documentation.

```shell
cargo watch --notify --shell "cargo doc --document-private-items"
```

EDIT:
Doctest support is missing from nextest/llvm-cov, which is annoying for coverage metrics.

EDIT 2:
Suprised there isn't a GHA to upload docs to pages, and comment a link on the PR.

Guess this PR is going to devolve into GHA shenanigans.

EDIT 3:
Pages doesn't support sub-paths. 
Need to wait until the 'preview' feature releases: https://github.com/actions/deploy-pages

We can add a docs preview to the main branch, which will still be useful for pre-release checks.

EDIT 4:
Noticed some inconsistencies around our error messages.

EDIT 5: 
Leaving the main, crate level documentation to a later date.