### PR TITLE
Remove unsafe usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["router"]
 categories = ["network-programming", "web-programming"]
 
-[workspace.lints.rust]
-unsafe_code = "forbid"
-
 [workspace.lints.clippy]
 cargo = { level = "deny", priority = -1 }
 complexity = { level = "deny", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["router"]
 categories = ["network-programming", "web-programming"]
 
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
 [workspace.lints.clippy]
 cargo = { level = "deny", priority = -1 }
 complexity = { level = "deny", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -312,14 +312,14 @@ In a router of 130 routes, benchmark matching 4 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 421.54 ns | 4           | 265 B      | 4             | 265 B        |
-| matchit          | 462.54 ns | 4           | 416 B      | 4             | 448 B        |
-| xitca-router     | 562.75 ns | 7           | 800 B      | 7             | 832 B        |
-| path-tree        | 584.14 ns | 4           | 416 B      | 4             | 448 B        |
-| ntex-router      | 1.8162 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
-| route-recognizer | 4.5801 µs | 160         | 8.515 KB   | 160           | 8.547 KB     |
-| routefinder      | 6.5709 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
-| actix-router     | 21.114 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
+| wayfind          | 413.09 ns | 4           | 265 B      | 4             | 265 B        |
+| matchit          | 460.29 ns | 4           | 416 B      | 4             | 448 B        |
+| xitca-router     | 563.49 ns | 7           | 800 B      | 7             | 832 B        |
+| path-tree        | 580.78 ns | 4           | 416 B      | 4             | 448 B        |
+| ntex-router      | 1.8109 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
+| route-recognizer | 4.5723 µs | 160         | 8.515 KB   | 160           | 8.547 KB     |
+| routefinder      | 6.4668 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
+| actix-router     | 21.120 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
 
 #### `path-tree` inspired benches
 
@@ -327,14 +327,14 @@ In a router of 320 routes, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 5.7638 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
-| matchit          | 8.9442 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
-| path-tree        | 9.5574 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
-| xitca-router     | 10.873 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
-| ntex-router      | 31.442 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
-| route-recognizer | 91.263 µs | 2872        | 191.8 KB   | 2872          | 205 KB       |
-| routefinder      | 98.438 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
-| actix-router     | 191.27 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
+| wayfind          | 6.4478 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
+| matchit          | 8.9103 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
+| path-tree        | 9.5161 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
+| xitca-router     | 10.832 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
+| ntex-router      | 30.906 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
+| route-recognizer | 90.866 µs | 2872        | 191.8 KB   | 2872          | 205 KB       |
+| routefinder      | 99.106 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
+| actix-router     | 178.31 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/README.md
+++ b/README.md
@@ -312,14 +312,14 @@ In a router of 130 routes, benchmark matching 4 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| matchit          | 458.45 ns | 4           | 416 B      | 4             | 448 B        |
-| wayfind          | 469.26 ns | 4           | 265 B      | 4             | 265 B        |
-| xitca-router     | 564.45 ns | 7           | 800 B      | 7             | 832 B        |
-| path-tree        | 586.60 ns | 4           | 416 B      | 4             | 448 B        |
-| ntex-router      | 1.8006 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
-| route-recognizer | 4.6234 µs | 160         | 8.515 KB   | 160           | 8.547 KB     |
-| routefinder      | 6.4700 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
-| actix-router     | 21.198 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
+| wayfind          | 421.54 ns | 4           | 265 B      | 4             | 265 B        |
+| matchit          | 462.54 ns | 4           | 416 B      | 4             | 448 B        |
+| xitca-router     | 562.75 ns | 7           | 800 B      | 7             | 832 B        |
+| path-tree        | 584.14 ns | 4           | 416 B      | 4             | 448 B        |
+| ntex-router      | 1.8162 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
+| route-recognizer | 4.5801 µs | 160         | 8.515 KB   | 160           | 8.547 KB     |
+| routefinder      | 6.5709 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
+| actix-router     | 21.114 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
 
 #### `path-tree` inspired benches
 
@@ -327,14 +327,14 @@ In a router of 320 routes, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 6.6642 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
-| matchit          | 9.1211 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
-| path-tree        | 9.5522 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
-| xitca-router     | 11.207 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
-| ntex-router      | 30.467 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
-| route-recognizer | 91.276 µs | 2872        | 191.8 KB   | 2872          | 205 KB       |
-| routefinder      | 99.490 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
-| actix-router     | 179.74 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
+| wayfind          | 5.7638 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
+| matchit          | 8.9442 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
+| path-tree        | 9.5574 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
+| xitca-router     | 10.873 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
+| ntex-router      | 31.442 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
+| route-recognizer | 91.263 µs | 2872        | 191.8 KB   | 2872          | 205 KB       |
+| routefinder      | 98.438 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
+| actix-router     | 191.27 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/benches/matchit_criterion.rs
+++ b/benches/matchit_criterion.rs
@@ -25,7 +25,7 @@ fn benchmark(criterion: &mut Criterion) {
         bencher.iter(|| {
             for route in black_box(paths()) {
                 let path = wayfind::Path::new(route).unwrap();
-                let output = black_box(router.search(black_box(&path)).unwrap());
+                let output = black_box(router.search(black_box(&path)).unwrap().unwrap());
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());
             }

--- a/benches/matchit_divan.rs
+++ b/benches/matchit_divan.rs
@@ -27,7 +27,7 @@ fn wayfind(bencher: divan::Bencher) {
     bencher.bench(|| {
         for route in black_box(paths()) {
             let path = wayfind::Path::new(route).unwrap();
-            let output = black_box(router.search(black_box(&path)).unwrap());
+            let output = black_box(router.search(black_box(&path)).unwrap().unwrap());
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());
         }

--- a/benches/path_tree_criterion.rs
+++ b/benches/path_tree_criterion.rs
@@ -25,7 +25,7 @@ fn benchmark(criterion: &mut Criterion) {
         bencher.iter(|| {
             for route in black_box(paths()) {
                 let path = wayfind::Path::new(route).unwrap();
-                let output = black_box(router.search(black_box(&path)).unwrap());
+                let output = black_box(router.search(black_box(&path)).unwrap().unwrap());
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());
             }

--- a/benches/path_tree_divan.rs
+++ b/benches/path_tree_divan.rs
@@ -27,7 +27,7 @@ fn wayfind(bencher: divan::Bencher) {
     bencher.bench(|| {
         for route in black_box(paths()) {
             let path = wayfind::Path::new(route).unwrap();
-            let output = black_box(router.search(black_box(&path)).unwrap());
+            let output = black_box(router.search(black_box(&path)).unwrap().unwrap());
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.parameters.iter().map(|p| (p.key, p.value)).collect());
         }

--- a/examples/hyper/src/main.rs
+++ b/examples/hyper/src/main.rs
@@ -66,7 +66,10 @@ async fn main() -> Result<(), anyhow::Error> {
                         async move {
                             let path = request.uri().path();
                             let wayfind_path = Path::new(path).expect("Invalid path!");
-                            let matches = router.search(&wayfind_path).expect("Failed to match!");
+                            let matches = router
+                                .search(&wayfind_path)
+                                .expect("Failed to search!")
+                                .expect("No match found!");
 
                             let handler = &matches.data.value;
                             let parameters = &matches.parameters;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,3 +16,6 @@ pub use path::PathError;
 
 pub(crate) mod route;
 pub use route::RouteError;
+
+pub(crate) mod search;
+pub use search::SearchError;

--- a/src/errors/path.rs
+++ b/src/errors/path.rs
@@ -36,45 +36,6 @@ pub enum PathError {
         /// The invalid character sequence.
         character: [u8; 3],
     },
-
-    /// Invalid UTF-8 sequence encountered.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use wayfind::errors::PathError;
-    ///
-    /// let error = PathError::Utf8Error {
-    ///     input: "/hello%FFworld".to_string(),
-    ///     decoded: "/hello�world".to_string(),
-    ///     position: 6,
-    ///     length: 1,
-    /// };
-    ///
-    /// let display = "
-    /// invalid UTF-8 sequence
-    ///
-    /// Original: /hello%FFworld
-    ///  Decoded: /hello�world
-    ///                 ^
-    ///
-    /// Expected: valid UTF-8 encoded characters
-    ///    Found: invalid byte sequence at position 6 after decoding
-    /// ";
-    ///
-    /// assert_eq!(error.to_string(), display.trim());
-    /// ```
-    Utf8Error {
-        /// The unaltered input string.
-        input: String,
-        /// The post-decoded input string.
-        /// This will contain UTF-8 replacement symbols.
-        decoded: String,
-        /// The position in the decoded string where the invalid UTF-8 was found.
-        position: usize,
-        /// The length of the invalid UTF-8 sequence.
-        length: usize,
-    },
 }
 
 impl Error for PathError {}
@@ -99,25 +60,6 @@ impl Display for PathError {
 
 Expected: '%' followed by two hexadecimal digits (a-F, 0-9)
    Found: '{character}'",
-                )
-            }
-            Self::Utf8Error {
-                input,
-                decoded,
-                position,
-                length,
-            } => {
-                let arrow = " ".repeat(*position) + &"^".repeat(*length);
-                write!(
-                    f,
-                    "invalid UTF-8 sequence
-
-Original: {input}
- Decoded: {decoded}
-          {arrow}
-
-Expected: valid UTF-8 encoded characters
-   Found: invalid byte sequence at position {position} after decoding",
                 )
             }
         }

--- a/src/errors/search.rs
+++ b/src/errors/search.rs
@@ -1,0 +1,17 @@
+use std::{error::Error, fmt::Display};
+
+/// Errors relating to attempting to search for a match in a [`Router`](crate::Router).
+#[derive(Debug, PartialEq, Eq)]
+pub enum SearchError {
+    InvalidParameter,
+}
+
+impl Error for SearchError {}
+
+impl Display for SearchError {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidParameter => todo!(),
+        }
+    }
+}

--- a/src/errors/search.rs
+++ b/src/errors/search.rs
@@ -3,15 +3,56 @@ use std::{error::Error, fmt::Display};
 /// Errors relating to attempting to search for a match in a [`Router`](crate::Router).
 #[derive(Debug, PartialEq, Eq)]
 pub enum SearchError {
-    InvalidParameter,
+    /// Invalid UTF-8 sequence encountered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::SearchError;
+    ///
+    /// let error = SearchError::Utf8Error {
+    ///     key: "parameter".to_string(),
+    ///     value: "hello�world".to_string(),
+    /// };
+    ///
+    /// let display = "
+    /// invalid UTF-8 sequence
+    ///
+    ///      Key: parameter
+    ///    Value: hello�world
+    ///
+    /// Expected: valid UTF-8 encoded characters
+    ///    Found: invalid byte sequence
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    Utf8Error {
+        /// The parameter key.
+        key: String,
+        /// The invalid parameter value.
+        /// This will contain UTF-8 replacement symbols.
+        value: String,
+    },
 }
 
 impl Error for SearchError {}
 
 impl Display for SearchError {
-    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidParameter => todo!(),
+            Self::Utf8Error { key, value } => {
+                write!(
+                    f,
+                    "invalid UTF-8 sequence
+
+     Key: {key}
+   Value: {value}
+
+Expected: valid UTF-8 encoded characters
+   Found: invalid byte sequence",
+                )
+            }
         }
     }
 }

--- a/src/node/search.rs
+++ b/src/node/search.rs
@@ -125,8 +125,10 @@ impl<T> Node<T> {
 
                 let mut current_parameters = parameters.clone();
                 current_parameters.push(Parameter {
-                    key: std::str::from_utf8(&dynamic_child.prefix)
-                        .map_err(|_| SearchError::InvalidParameter)?,
+                    key: {
+                        debug_assert!(std::str::from_utf8(&dynamic_child.prefix).is_ok());
+                        unsafe { std::str::from_utf8_unchecked(&dynamic_child.prefix) }
+                    },
                     value: std::str::from_utf8(segment)
                         .map_err(|_| SearchError::InvalidParameter)?,
                 });
@@ -164,8 +166,10 @@ impl<T> Node<T> {
             }
 
             parameters.push(Parameter {
-                key: std::str::from_utf8(&dynamic_child.prefix)
-                    .map_err(|_| SearchError::InvalidParameter)?,
+                key: {
+                    debug_assert!(std::str::from_utf8(&dynamic_child.prefix).is_ok());
+                    unsafe { std::str::from_utf8_unchecked(&dynamic_child.prefix) }
+                },
                 value: std::str::from_utf8(segment).map_err(|_| SearchError::InvalidParameter)?,
             });
 
@@ -221,8 +225,10 @@ impl<T> Node<T> {
                 }
 
                 parameters.push(Parameter {
-                    key: std::str::from_utf8(&wildcard_child.prefix)
-                        .map_err(|_| SearchError::InvalidParameter)?,
+                    key: {
+                        debug_assert!(std::str::from_utf8(&wildcard_child.prefix).is_ok());
+                        unsafe { std::str::from_utf8_unchecked(&wildcard_child.prefix) }
+                    },
                     value: std::str::from_utf8(segment)
                         .map_err(|_| SearchError::InvalidParameter)?,
                 });
@@ -254,19 +260,21 @@ impl<T> Node<T> {
         parameters: &mut SmallVec<[Parameter<'router, 'path>; 4]>,
         constraints: &HashMap<Vec<u8>, StoredConstraint>,
     ) -> Result<Option<&'router Self>, SearchError> {
-        for end_wildcard in &self.end_wildcard_children {
-            if !Self::check_constraint(end_wildcard, path, constraints) {
+        for end_wildcard_child in &self.end_wildcard_children {
+            if !Self::check_constraint(end_wildcard_child, path, constraints) {
                 continue;
             }
 
             parameters.push(Parameter {
-                key: std::str::from_utf8(&end_wildcard.prefix)
-                    .map_err(|_| SearchError::InvalidParameter)?,
+                key: {
+                    debug_assert!(std::str::from_utf8(&end_wildcard_child.prefix).is_ok());
+                    unsafe { std::str::from_utf8_unchecked(&end_wildcard_child.prefix) }
+                },
                 value: std::str::from_utf8(path).map_err(|_| SearchError::InvalidParameter)?,
             });
 
-            return if end_wildcard.data.is_some() {
-                Ok(Some(end_wildcard))
+            return if end_wildcard_child.data.is_some() {
+                Ok(Some(end_wildcard_child))
             } else {
                 Ok(None)
             };

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 #[derive(Debug)]
 pub struct Path<'path> {
     /// Original, unaltered path bytes.
-    raw: &'path [u8],
+    _raw: &'path [u8],
 
     /// Percent-decoded path bytes.
     decoded: Cow<'path, [u8]>,
@@ -16,7 +16,7 @@ impl<'path> Path<'path> {
     ///
     /// # Errors
     ///
-    /// Will error if the path can't be created, due to invalid percent-encoding, or invalid UTF-8 post-decoding.
+    /// Will error if the path can't be created, due to invalid percent-encoding.
     ///
     /// # Examples
     ///
@@ -26,11 +26,10 @@ impl<'path> Path<'path> {
     /// use wayfind::Path;
     ///
     /// let path = Path::new("/hello%20world").unwrap();
-    /// assert_eq!(path.raw_bytes(), b"/hello%20world");
     /// assert_eq!(path.decoded_bytes(), b"/hello world");
     /// ```
     ///
-    /// ## Invalid Encoding
+    /// ## Invalid
     ///
     /// ```rust
     /// use wayfind::{Path, errors::PathError};
@@ -42,43 +41,17 @@ impl<'path> Path<'path> {
     ///     character: [b'%', b'G', b'G'],
     /// });
     /// ```
-    ///
-    /// ## Invalid UTF-8
-    ///
-    /// ```rust
-    /// use wayfind::{Path, errors::PathError};
-    ///
-    /// let path = Path::new("/hello%FFworld").unwrap_err();
-    /// assert_eq!(path, PathError::Utf8Error {
-    ///     input: "/hello%FFworld".to_string(),
-    ///     decoded: "/hello�world".to_string(),
-    ///     position: 6,
-    ///     length: 1,
-    /// });
-    /// ```
     pub fn new(path: &'path str) -> Result<Self, PathError> {
         let decoded = percent_decode(path.as_bytes())?;
-        std::str::from_utf8(&decoded).map_err(|err| PathError::Utf8Error {
-            input: path.to_string(),
-            decoded: String::from_utf8_lossy(&decoded).to_string(),
-            position: err.valid_up_to(),
-            length: err.error_len().unwrap_or(1),
-        })?;
 
         Ok(Self {
-            raw: path.as_bytes(),
+            _raw: path.as_bytes(),
             decoded,
         })
     }
 
-    /// Returns a reference to the original path bytes.
-    #[must_use]
-    pub const fn raw_bytes(&'path self) -> &'path [u8] {
-        self.raw
-    }
-
     /// Returns a reference to the percent-decoded path bytes.
-    /// Guaranteed to be valid UTF-8, via a check in [`Path::new`].
+    /// May contain invalid UTF-8 bytes.
     #[must_use]
     pub fn decoded_bytes(&'path self) -> &'path [u8] {
         &self.decoded

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -51,7 +51,7 @@ pub fn assert_router_match<'a, T: PartialEq + Debug>(
     expected: Option<ExpectedMatch<'_, 'a, T>>,
 ) {
     let path = Path::new(input).expect("Invalid path!");
-    let Some(Match { data, parameters }) = router.search(&path) else {
+    let Ok(Some(Match { data, parameters })) = router.search(&path) else {
         assert!(expected.is_none(), "No match found for input: {input}");
         return;
     };


### PR DESCRIPTION
Fuzzers work!

Need to think about how to optimize the UTF-8 checks.

Should we delay UTF-8 checks until post-inner-search?
Or would that result in unnecessary work?

Could we remove the UTF-8 check after percent-decoding?
Since we never actually return the provided decoded path.

Could we still use unsafe for the 'key'?