### PR TITLE
Add optional path parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional parameters are now supported in routes.
+
 ### Changed
 
 - Successful matches now return a flattened representation of node data.

--- a/src/expander.rs
+++ b/src/expander.rs
@@ -1,0 +1,298 @@
+use crate::parser::{ParsedRoute, RoutePart, RouteParts};
+use std::collections::VecDeque;
+
+/// Represents a collection of expanded, simplified routes, derived from an original route.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ExpandedRoutes {
+    pub raw: ParsedRoute,
+    pub routes: Vec<ParsedRoute>,
+}
+
+impl ExpandedRoutes {
+    pub fn new(route: ParsedRoute) -> Self {
+        let mut routes = VecDeque::new();
+        Self::recursive_expand(route.parts.0.clone(), VecDeque::new(), &mut routes);
+
+        let routes =
+            routes
+                .into_iter()
+                .map(|parts| {
+                    // Handle special case, where optional is at the start of a route.
+                    // Replace with a single "/" part.
+                    if parts.0.iter().all(
+                        |part| matches!(part, RoutePart::Static { prefix } if prefix.is_empty()),
+                    ) {
+                        RouteParts(VecDeque::from(vec![RoutePart::Static {
+                            prefix: b"/".to_vec(),
+                        }]))
+                    } else {
+                        parts
+                    }
+                })
+                .map(ParsedRoute::from)
+                .collect();
+
+        Self { raw: route, routes }
+    }
+
+    fn recursive_expand(
+        mut remaining: VecDeque<RoutePart>,
+        mut current: VecDeque<RoutePart>,
+        expanded: &mut VecDeque<RouteParts>,
+    ) {
+        let Some(part) = remaining.pop_front() else {
+            expanded.push_back(RouteParts(current));
+            return;
+        };
+
+        match part {
+            RoutePart::Static { .. }
+            | RoutePart::Dynamic {
+                optional: false, ..
+            }
+            | RoutePart::Wildcard {
+                optional: false, ..
+            } => {
+                current.push_back(part);
+                Self::recursive_expand(remaining, current, expanded);
+            }
+            RoutePart::Dynamic { .. } | RoutePart::Wildcard { .. } => {
+                // Handle optional present case
+                let mut new_part = part.clone();
+                new_part.disable_optional();
+                let mut new_route = current.clone();
+                new_route.push_back(new_part);
+                Self::recursive_expand(remaining.clone(), new_route, expanded);
+
+                // Handle optional absent case
+                // TODO: Consider calculating this at insert time.
+                // Then we could handle this at the match level?
+                let is_segment = matches!(&part, RoutePart::Static { .. })
+                    || current.back().map_or(true, RoutePart::ends_with_slash)
+                    || remaining.front().map_or(true, RoutePart::starts_with_slash);
+
+                if is_segment {
+                    // Trim the prior `/`, if exists.
+                    if let Some(RoutePart::Static { prefix }) = current.back_mut() {
+                        prefix.pop();
+                    }
+
+                    Self::recursive_expand(remaining, current, expanded);
+                } else {
+                    // Trim any prior static characters.
+                    let mut current = current.clone();
+                    while let Some(last) = current.back() {
+                        if matches!(last, RoutePart::Static { prefix } if !prefix.is_empty() && !last.ends_with_slash())
+                        {
+                            current.pop_back();
+                        } else {
+                            break;
+                        }
+                    }
+
+                    expanded.push_back(RouteParts(current));
+                }
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use similar_asserts::assert_eq;
+    use std::error::Error;
+
+    #[test]
+    fn test_expander_segment_simple() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/users/{id?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/users/{id}")?,
+                    ParsedRoute::new(b"/users")?
+                ],
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_segment_simple_suffix() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/users/{id?}/info")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/users/{id}/info")?,
+                    ParsedRoute::new(b"/users/info")?
+                ],
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_segment_multiple() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/users/{id?}/{name?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/users/{id}/{name}")?,
+                    ParsedRoute::new(b"/users/{id}")?,
+                    ParsedRoute::new(b"/users/{name}")?,
+                    ParsedRoute::new(b"/users")?,
+                ]
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_segment_constraint() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/users/{id?:int}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/users/{id:int}")?,
+                    ParsedRoute::new(b"/users")?,
+                ]
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_segment_all_optional() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/{category?}/{subcategory?}/{id?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/{category}/{subcategory}/{id}")?,
+                    ParsedRoute::new(b"/{category}/{subcategory}")?,
+                    ParsedRoute::new(b"/{category}/{id}")?,
+                    ParsedRoute::new(b"/{category}")?,
+                    ParsedRoute::new(b"/{subcategory}/{id}")?,
+                    ParsedRoute::new(b"/{subcategory}")?,
+                    ParsedRoute::new(b"/{id}")?,
+                    ParsedRoute::new(b"/")?,
+                ]
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_segment_mixed() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/api/{version}/{resource}/{id?}/details")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/api/{version}/{resource}/{id}/details")?,
+                    ParsedRoute::new(b"/api/{version}/{resource}/details")?,
+                ]
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_inline_simple() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/files/{name}.{extension?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/files/{name}.{extension}")?,
+                    ParsedRoute::new(b"/files/{name}")?,
+                ],
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_inline_multiple() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/release/v{major}.{minor?}.{patch?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![
+                    ParsedRoute::new(b"/release/v{major}.{minor}.{patch}")?,
+                    ParsedRoute::new(b"/release/v{major}.{minor}")?,
+                    ParsedRoute::new(b"/release/v{major}")?,
+                ],
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_start() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"{id?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![ParsedRoute::new(b"{id}")?, ParsedRoute::new(b"/")?,],
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_expander_start_slash() -> Result<(), Box<dyn Error>> {
+        let route = ParsedRoute::new(b"/{id?}")?;
+        let expanded = ExpandedRoutes::new(route.clone());
+
+        assert_eq!(
+            expanded,
+            ExpandedRoutes {
+                raw: route,
+                routes: vec![ParsedRoute::new(b"/{id}")?, ParsedRoute::new(b"/")?,],
+            }
+        );
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub(crate) mod decode;
 
 pub mod errors;
 
+pub(crate) mod expander;
+
 pub(crate) mod node;
 pub use node::search::{Match, Parameter};
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,10 +38,12 @@ pub enum NodeData<T> {
     },
 
     /// Data is shared between 2 or more nodes.
-    #[allow(dead_code)]
     Shared {
         /// The original route.
         route: Arc<str>,
+
+        /// The expanded route.
+        expanded: Arc<str>,
 
         /// The associated data, shared.
         value: Arc<T>,

--- a/src/node/insert.rs
+++ b/src/node/insert.rs
@@ -12,26 +12,32 @@ impl<T> Node<T> {
     /// Will error is there's already data at the end node.
     pub fn insert(
         &mut self,
-        route: &mut ParsedRoute<'_>,
+        route: &mut ParsedRoute,
         data: NodeData<T>,
     ) -> Result<(), InsertError> {
         if let Some(part) = route.parts.pop_front() {
             match part {
                 RoutePart::Static { prefix } => self.insert_static(route, data, &prefix)?,
-                RoutePart::Dynamic { name, constraint } => {
+                RoutePart::Dynamic {
+                    name, constraint, ..
+                } => {
                     self.insert_dynamic(route, data, &name, constraint)?;
                 }
-                RoutePart::Wildcard { name, constraint } if route.parts.is_empty() => {
+                RoutePart::Wildcard {
+                    name, constraint, ..
+                } if route.parts.is_empty() => {
                     self.insert_end_wildcard(route, data, &name, constraint)?;
                 }
-                RoutePart::Wildcard { name, constraint } => {
+                RoutePart::Wildcard {
+                    name, constraint, ..
+                } => {
                     self.insert_wildcard(route, data, &name, constraint)?;
                 }
             };
         } else {
             if self.data.is_some() {
                 return Err(InsertError::DuplicateRoute {
-                    route: String::from_utf8_lossy(route.raw).to_string(),
+                    route: String::from_utf8_lossy(&route.raw).to_string(),
                 });
             }
 
@@ -46,7 +52,7 @@ impl<T> Node<T> {
 
     fn insert_static(
         &mut self,
-        route: &mut ParsedRoute<'_>,
+        route: &mut ParsedRoute,
         data: NodeData<T>,
         prefix: &[u8],
     ) -> Result<(), InsertError> {
@@ -142,7 +148,7 @@ impl<T> Node<T> {
 
     fn insert_dynamic(
         &mut self,
-        route: &mut ParsedRoute<'_>,
+        route: &mut ParsedRoute,
         data: NodeData<T>,
         name: &[u8],
         constraint: Option<Vec<u8>>,
@@ -180,7 +186,7 @@ impl<T> Node<T> {
 
     fn insert_wildcard(
         &mut self,
-        route: &mut ParsedRoute<'_>,
+        route: &mut ParsedRoute,
         data: NodeData<T>,
         name: &[u8],
         constraint: Option<Vec<u8>>,
@@ -218,7 +224,7 @@ impl<T> Node<T> {
 
     fn insert_end_wildcard(
         &mut self,
-        route: &ParsedRoute<'_>,
+        route: &ParsedRoute,
         data: NodeData<T>,
         name: &[u8],
         constraint: Option<Vec<u8>>,
@@ -229,7 +235,7 @@ impl<T> Node<T> {
             .any(|child| child.prefix == name && child.constraint == constraint)
         {
             return Err(InsertError::DuplicateRoute {
-                route: String::from_utf8_lossy(route.raw).to_string(),
+                route: String::from_utf8_lossy(&route.raw).to_string(),
             });
         }
 

--- a/src/node/search.rs
+++ b/src/node/search.rs
@@ -8,6 +8,9 @@ pub struct Match<'router, 'path, T> {
     /// The matching route.
     pub route: Arc<str>,
 
+    /// The expanded route, if applicable.
+    pub expanded: Option<Arc<str>>,
+
     /// A reference to the matching route data.
     pub data: &'router T,
 
@@ -175,7 +178,8 @@ impl<T> Node<T> {
         };
 
         match data {
-            NodeData::Inline { route, .. } | NodeData::Shared { route, .. } => route.len(),
+            NodeData::Inline { route, .. } => route.len(),
+            NodeData::Shared { expanded, .. } => expanded.len(),
         }
     }
 

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -5,7 +5,7 @@ use wayfind::Router;
 mod utils;
 
 #[test]
-fn test_depth_matching_simple() -> Result<(), Box<dyn Error>> {
+fn test_specific_matching_simple() -> Result<(), Box<dyn Error>> {
     let mut router = Router::new();
     router.insert("/{file}", 1)?;
     router.insert("/{file}.{extension}", 1)?;
@@ -40,7 +40,7 @@ fn test_depth_matching_simple() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-fn test_depth_matching_complex() -> Result<(), Box<dyn Error>> {
+fn test_specific_matching_complex() -> Result<(), Box<dyn Error>> {
     let mut router = Router::new();
     router.insert("/{year}", 1)?;
     router.insert("/{year}-{month}", 1)?;

--- a/tests/optionals.rs
+++ b/tests/optionals.rs
@@ -1,0 +1,94 @@
+#![allow(clippy::too_many_lines)]
+
+use std::error::Error;
+use wayfind::Router;
+
+#[path = "./utils.rs"]
+mod utils;
+
+#[test]
+fn test_optional_wildcards() -> Result<(), Box<dyn Error>> {
+    let mut router = Router::new();
+    router.insert("/{*name?}/abc", 1)?;
+    router.insert("/def/{*rest?}", 2)?;
+    router.insert("/{*prefix?}/ghi/{*suffix?}", 3)?;
+
+    insta::assert_snapshot!(router, @r#"
+    ▽
+    ╰─ /
+       ├─ abc ○
+       ├─ def ○
+       │    ╰─ /
+       │       ╰─ {*rest} ○
+       ├─ ghi ○
+       │    ╰─ /
+       │       ╰─ {*suffix} ○
+       ├─ {*name}
+       │        ╰─ /abc ○
+       ╰─ {*prefix}
+                  ╰─ /ghi ○
+                        ╰─ /
+                           ╰─ {*suffix} ○
+    "#);
+
+    assert_router_matches!(router, {
+        "/abc" => {
+            route: "/{*name?}/abc",
+            expanded: "/abc",
+            data: 1
+        }
+        "/xyz/abc" => {
+            route: "/{*name?}/abc",
+            expanded: "/{*name}/abc",
+            data: 1,
+            params: {
+                "name" => "xyz"
+            }
+        }
+        "/def" => {
+            route: "/def/{*rest?}",
+            expanded: "/def",
+            data: 2
+        }
+        "/def/some/path" => {
+            route: "/def/{*rest?}",
+            expanded: "/def/{*rest}",
+            data: 2,
+            params: {
+                "rest" => "some/path"
+            }
+        }
+        "/ghi" => {
+            route: "/{*prefix?}/ghi/{*suffix?}",
+            expanded: "/ghi",
+            data: 3
+        }
+        "/prefix/ghi" => {
+            route: "/{*prefix?}/ghi/{*suffix?}",
+            expanded: "/{*prefix}/ghi",
+            data: 3,
+            params: {
+                "prefix" => "prefix"
+            }
+        }
+        "/ghi/suffix" => {
+            route: "/{*prefix?}/ghi/{*suffix?}",
+            expanded: "/ghi/{*suffix}",
+            data: 3,
+            params: {
+                "suffix" => "suffix"
+            }
+        }
+        "/prefix/ghi/suffix" => {
+            route: "/{*prefix?}/ghi/{*suffix?}",
+            expanded: "/{*prefix}/ghi/{*suffix}",
+            data: 3,
+            params: {
+                "prefix" => "prefix",
+                "suffix" => "suffix"
+            }
+        }
+    });
+
+    Ok(())
+}

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -2,6 +2,13 @@ use similar_asserts::assert_eq;
 use std::{fmt::Debug, sync::Arc};
 use wayfind::{Match, Parameter, Path, Router};
 
+pub struct ExpectedMatch<'k, 'v, T> {
+    pub route: Arc<str>,
+    pub expanded: Option<Arc<str>>,
+    pub data: T,
+    pub params: Vec<Parameter<'k, 'v>>,
+}
+
 #[macro_export]
 macro_rules! assert_router_matches {
     ($router:expr, {
@@ -15,6 +22,7 @@ macro_rules! assert_router_matches {
 
     (@parse_expected {
         route: $route:expr,
+        expanded: $expanded:expr,
         data: $data:expr
         $(, params: {
             $($param_key:expr => $param_value:expr),+
@@ -22,6 +30,29 @@ macro_rules! assert_router_matches {
     }) => {
         Some($crate::utils::ExpectedMatch {
             route: std::sync::Arc::from($route),
+            expanded: Some(std::sync::Arc::from($expanded)),
+            data: $data,
+            params: vec![
+                $(
+                    $( wayfind::Parameter {
+                        key: $param_key,
+                        value: $param_value,
+                    } ),+
+                )?
+            ]
+        })
+    };
+
+    (@parse_expected {
+        route: $route:expr,
+        data: $data:expr
+        $(, params: {
+            $($param_key:expr => $param_value:expr),+
+        })?
+    }) => {
+        Some($crate::utils::ExpectedMatch {
+            route: std::sync::Arc::from($route),
+            expanded: None,
             data: $data,
             params: vec![
                 $(
@@ -39,12 +70,6 @@ macro_rules! assert_router_matches {
     };
 }
 
-pub struct ExpectedMatch<'k, 'v, T> {
-    pub route: Arc<str>,
-    pub data: T,
-    pub params: Vec<Parameter<'k, 'v>>,
-}
-
 #[allow(clippy::missing_panics_doc)]
 pub fn assert_router_match<'a, T: PartialEq + Debug>(
     router: &'a Router<T>,
@@ -54,6 +79,7 @@ pub fn assert_router_match<'a, T: PartialEq + Debug>(
     let path = Path::new(input).expect("Invalid path!");
     let Ok(Some(Match {
         route,
+        expanded,
         data,
         parameters,
     })) = router.search(&path)
@@ -63,8 +89,12 @@ pub fn assert_router_match<'a, T: PartialEq + Debug>(
     };
 
     if let Some(expected) = expected {
-        assert_eq!(route, expected.route, "Path mismatch for input: {input}");
-        assert_eq!(*data, expected.data, "Value mismatch for input: {input}");
+        assert_eq!(route, expected.route, "Route mismatch for input: {input}");
+        assert_eq!(
+            expanded, expected.expanded,
+            "Expanded mismatch for input: {input}"
+        );
+        assert_eq!(*data, expected.data, "Data mismatch for input: {input}");
         assert_eq!(
             parameters, expected.params,
             "Parameters mismatch for input: {input}"


### PR DESCRIPTION
Realising that with this approach, we can have any number of optionals, anywhere in a route.

Not sure if that's a good thing or not.

Long term, I'd like to add a real parser that can do this in one pass, but the additive approach is fine for now. Once we have benchmarks for inserts/deletes, that will help. Syntax isn't really "set" yet, either.

This is 'good enough' for now.