### PR TITLE
Improve insert/delete performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ corpus
 artifacts
 coverage
 
+# Samply
+profile.json
+
 # OCI
 junit.xml
 report.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Inserts and deletes should be much more efficient now.
 - Syntax for escaping parameters has changed to use the `\` character.
 - Route errors now have more consistent error messages.
 - Duplicate route error now shows which route caused the conflict.

--- a/benches/gitlab_criterion.rs
+++ b/benches/gitlab_criterion.rs
@@ -1,6 +1,6 @@
 use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Criterion};
 use gitlab_routes::routes;
-use std::{hint::black_box, time::Duration};
+use std::hint::black_box;
 
 pub mod gitlab_routes;
 
@@ -13,8 +13,6 @@ criterion_group! {
 
 fn insert_benchmark(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("gitlab insert benchmarks");
-    group.sample_size(50);
-    group.measurement_time(Duration::from_secs(10));
 
     group.bench_function("gitlab insert benchmarks/wayfind", |bencher| {
         let router = wayfind::Router::new();
@@ -34,8 +32,6 @@ fn insert_benchmark(criterion: &mut Criterion) {
 
 fn delete_benchmark(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("gitlab delete benchmarks");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(15));
 
     group.bench_function("gitlab delete benchmarks/wayfind", |bencher| {
         let mut router = wayfind::Router::new();

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
               # Benchmarking
               cargo-codspeed
               gnuplot
+              samply
 
               # Release
               cargo-semver-checks

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,13 +1,44 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    cmp::Ordering,
+    fmt::Debug,
+    ops::{Index, IndexMut},
+    sync::Arc,
+};
 
 pub mod delete;
 pub mod display;
 pub mod insert;
+pub mod optimize;
 pub mod search;
+
+/// Represents a node in the tree structure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Node<T> {
+    pub kind: Kind,
+
+    /// The prefix may either be the static bytes of a path, or the name of a variable.
+    pub prefix: Vec<u8>,
+    /// Optional data associated with this node.
+    /// The presense of this data is needed to successfully match a route.
+    pub data: Option<Data<T>>,
+    /// An optional check to run, to restrict routing to this node.
+    pub constraint: Option<Vec<u8>>,
+
+    pub static_children: Children<T>,
+    pub dynamic_children: Children<T>,
+    pub wildcard_children: Children<T>,
+    pub end_wildcard_children: Children<T>,
+
+    /// A flag indicating whether this node's dynamic children can be matched quickly.
+    /// This allows us to traverse the next section of the path by segment, rather than byte-by-byte, when matching.
+    pub quick_dynamic: bool,
+    /// Flag indicating whether this node or its children need optimization.
+    pub needs_optimization: bool,
+}
 
 /// A node in the router tree structure.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum NodeKind {
+pub enum Kind {
     /// The root node of the tree.
     /// Must only be used in the [`Router::new`](crate::Router::new) method.
     Root,
@@ -27,7 +58,7 @@ pub enum NodeKind {
 
 /// Holds data associated with a given node.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum NodeData<T> {
+pub enum Data<T> {
     /// Data is stored inline.
     Inline {
         /// The original route.
@@ -50,25 +81,88 @@ pub enum NodeData<T> {
     },
 }
 
-/// Represents a node in the tree structure.
+/// A list of node children.
+/// Maintains whether it is sorted automatically.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Node<T> {
-    pub kind: NodeKind,
+pub struct Children<T> {
+    nodes: Vec<Node<T>>,
+    sorted: bool,
+}
 
-    /// The prefix may either be the static bytes of a path, or the name of a variable.
-    pub prefix: Vec<u8>,
-    /// Optional data associated with this node.
-    /// The presense of this data is needed to successfully match a route.
-    pub data: Option<NodeData<T>>,
-    /// An optional check to run, to restrict routing to this node.
-    pub constraint: Option<Vec<u8>>,
+impl<T> Children<T> {
+    fn push(&mut self, node: Node<T>) {
+        self.nodes.push(node);
+        self.sorted = false;
+    }
 
-    pub static_children: Vec<Node<T>>,
-    pub dynamic_children: Vec<Node<T>>,
-    pub wildcard_children: Vec<Node<T>>,
-    pub end_wildcard_children: Vec<Node<T>>,
+    fn remove(&mut self, index: usize) -> Node<T> {
+        self.nodes.remove(index)
+    }
 
-    /// A flag indicating whether this node's dynamic children can be matched quickly.
-    /// This allows us to traverse the next section of the path by segment, rather than byte-by-byte, when matching.
-    pub quick_dynamic: bool,
+    fn sort(&mut self) {
+        if self.sorted {
+            return;
+        }
+
+        self.nodes.sort_by(
+            |a, b| match (a.constraint.is_some(), b.constraint.is_some()) {
+                (true, false) => Ordering::Less,
+                (false, true) => Ordering::Greater,
+                _ => a.prefix.cmp(&b.prefix),
+            },
+        );
+
+        self.sorted = true;
+    }
+
+    fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    fn find_mut<F>(&mut self, predicate: F) -> Option<&mut Node<T>>
+    where
+        F: Fn(&Node<T>) -> bool,
+    {
+        self.nodes.iter_mut().find(|node| predicate(node))
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Node<T>> {
+        self.nodes.iter()
+    }
+
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Node<T>> {
+        self.nodes.iter_mut()
+    }
+}
+
+impl<T> Default for Children<T> {
+    fn default() -> Self {
+        Self {
+            nodes: vec![],
+            sorted: true,
+        }
+    }
+}
+
+impl<T> From<Vec<Node<T>>> for Children<T> {
+    fn from(value: Vec<Node<T>>) -> Self {
+        Self {
+            nodes: value,
+            sorted: false,
+        }
+    }
+}
+
+impl<T> Index<usize> for Children<T> {
+    type Output = Node<T>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.nodes[index]
+    }
+}
+
+impl<T> IndexMut<usize> for Children<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.nodes[index]
+    }
 }

--- a/src/node/display.rs
+++ b/src/node/display.rs
@@ -1,5 +1,5 @@
 use super::Node;
-use crate::node::NodeKind;
+use crate::node::Kind;
 use std::fmt::{Display, Write};
 
 impl<T> Display for Node<T> {
@@ -13,16 +13,16 @@ impl<T> Display for Node<T> {
         ) -> std::fmt::Result {
             let constraint = node.constraint.as_ref().map(|c| String::from_utf8_lossy(c));
             let key = match &node.kind {
-                NodeKind::Root => "▽".to_string(),
-                NodeKind::Static => String::from_utf8_lossy(&node.prefix).to_string(),
-                NodeKind::Dynamic => {
+                Kind::Root => "▽".to_string(),
+                Kind::Static => String::from_utf8_lossy(&node.prefix).to_string(),
+                Kind::Dynamic => {
                     let name = String::from_utf8_lossy(&node.prefix);
                     constraint.map_or_else(
                         || format!("{{{name}}}"),
                         |constraint| format!("{{{name}:{constraint}}}"),
                     )
                 }
-                NodeKind::Wildcard | NodeKind::EndWildcard => {
+                Kind::Wildcard | Kind::EndWildcard => {
                     let name = String::from_utf8_lossy(&node.prefix);
                     constraint.map_or_else(
                         || format!("{{*{name}}}"),

--- a/src/node/optimize.rs
+++ b/src/node/optimize.rs
@@ -1,0 +1,61 @@
+use crate::node::Node;
+
+impl<T> Node<T> {
+    /// Re-optimizes the tree after an insert/delete.
+    pub(crate) fn optimize(&mut self) {
+        if !self.needs_optimization {
+            return;
+        }
+
+        self.static_children.sort();
+        self.dynamic_children.sort();
+        self.wildcard_children.sort();
+        self.end_wildcard_children.sort();
+
+        for children in [
+            &mut self.static_children,
+            &mut self.dynamic_children,
+            &mut self.wildcard_children,
+            &mut self.end_wildcard_children,
+        ] {
+            for child in children.iter_mut() {
+                child.optimize();
+            }
+        }
+
+        self.update_quicks();
+        self.needs_optimization = false;
+    }
+
+    /// Check if we can short-cut our searching logic for dynamic children.
+    /// Instead of walking each path byte-by-byte, we can instead just to the next '/' character.
+    /// This only works if there are no inline dynamic children, e.g. `/{name}.{ext}`.
+    fn update_quicks(&mut self) {
+        self.quick_dynamic = self.dynamic_children.iter().all(|child| {
+            // Leading slash?
+            if child.prefix.first() == Some(&b'/') {
+                return true;
+            }
+
+            // No children?
+            if child.static_children.is_empty()
+                && child.dynamic_children.is_empty()
+                && child.wildcard_children.is_empty()
+                && child.end_wildcard_children.is_empty()
+            {
+                return true;
+            }
+
+            // All static children start with a slash?
+            if child
+                .static_children
+                .iter()
+                .all(|child| child.prefix.first() == Some(&b'/'))
+            {
+                return true;
+            }
+
+            false
+        });
+    }
+}

--- a/src/node/search.rs
+++ b/src/node/search.rs
@@ -1,4 +1,4 @@
-use super::{Node, NodeData};
+use super::{Data, Node};
 use crate::{errors::SearchError, router::StoredConstraint};
 use std::{collections::HashMap, sync::Arc};
 
@@ -72,7 +72,7 @@ impl<T> Node<T> {
         parameters: &mut Vec<Parameter<'router, 'path>>,
         constraints: &HashMap<Vec<u8>, StoredConstraint>,
     ) -> Result<Option<&'router Self>, SearchError> {
-        for static_child in &self.static_children {
+        for static_child in self.static_children.iter() {
             // This was previously a "starts_with" call, but turns out this is much faster.
             if path.len() >= static_child.prefix.len()
                 && static_child.prefix.iter().zip(path).all(|(a, b)| a == b)
@@ -109,7 +109,7 @@ impl<T> Node<T> {
         parameters: &mut Vec<Parameter<'router, 'path>>,
         constraints: &HashMap<Vec<u8>, StoredConstraint>,
     ) -> Result<Option<&'router Self>, SearchError> {
-        for dynamic_child in &self.dynamic_children {
+        for dynamic_child in self.dynamic_children.iter() {
             let mut consumed = 0;
 
             // Often the last match, except for when we have multiple options on the same branch.
@@ -178,8 +178,8 @@ impl<T> Node<T> {
         };
 
         match data {
-            NodeData::Inline { route, .. } => route.len(),
-            NodeData::Shared { expanded, .. } => expanded.len(),
+            Data::Inline { route, .. } => route.len(),
+            Data::Shared { expanded, .. } => expanded.len(),
         }
     }
 
@@ -190,7 +190,7 @@ impl<T> Node<T> {
         parameters: &mut Vec<Parameter<'router, 'path>>,
         constraints: &HashMap<Vec<u8>, StoredConstraint>,
     ) -> Result<Option<&'router Self>, SearchError> {
-        for dynamic_child in &self.dynamic_children {
+        for dynamic_child in self.dynamic_children.iter() {
             let segment_end = path.iter().position(|&b| b == b'/').unwrap_or(path.len());
 
             let segment = &path[..segment_end];
@@ -229,7 +229,7 @@ impl<T> Node<T> {
         parameters: &mut Vec<Parameter<'router, 'path>>,
         constraints: &HashMap<Vec<u8>, StoredConstraint>,
     ) -> Result<Option<&'router Self>, SearchError> {
-        for wildcard_child in &self.wildcard_children {
+        for wildcard_child in self.wildcard_children.iter() {
             let mut consumed = 0;
             let mut remaining_path = path;
             let mut section_end = false;
@@ -302,7 +302,7 @@ impl<T> Node<T> {
         parameters: &mut Vec<Parameter<'router, 'path>>,
         constraints: &HashMap<Vec<u8>, StoredConstraint>,
     ) -> Result<Option<&'router Self>, SearchError> {
-        for end_wildcard_child in &self.end_wildcard_children {
+        for end_wildcard_child in self.end_wildcard_children.iter() {
             if !Self::check_constraint(end_wildcard_child, path, constraints) {
                 continue;
             }


### PR DESCRIPTION
Tried to reduce how often we sort by tracking changes.
Also updated the quicks and performed sort in a single walk of the tree.

Removing the 'sort' logic results in -12% to the time.
Removing the 'quicks' logic results in -3% to the time.

So the real issue here is walking the tree, not the cost of any one action. The walk itself takes up 85% of the time.

We should aim to be able to say 'this whole branch is already optimized'.

If we end up creating a 'Children' struct to wrap the vec, maybe we should consider more refactors elsewhere.

Ideally we'd have some way to know if a child and it's children have already been optimized, so we can short-circuit the functions.

Saying that - I'd rather be overly cautious if unsure on the approach.