### PR TITLE
Add routable builder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support builder pattern for constructing routables.
+
 ### Changed
 
 - All routes now require a leading `/`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1040,9 +1040,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno",

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 
 A speedy, flexible router for Rust.
 
-> [!NOTE]
-> `wayfind` is still a work in progress.
+NOTE: `wayfind` is still a work in progress.
 
 ## Why another router?
 

--- a/benches/path_tree_criterion.rs
+++ b/benches/path_tree_criterion.rs
@@ -21,7 +21,7 @@ fn path_tree_benchmark(criterion: &mut Criterion) {
     group.bench_function("path-tree benchmarks/wayfind", |bencher| {
         let mut router = wayfind::Router::new();
         for (index, route) in routes!(brackets).iter().enumerate() {
-            router.insert(route, index).unwrap();
+            router.insert(*route, index).unwrap();
         }
 
         bencher.iter(|| {

--- a/benches/path_tree_divan.rs
+++ b/benches/path_tree_divan.rs
@@ -19,7 +19,7 @@ fn main() {
 fn wayfind(bencher: divan::Bencher<'_, '_>) {
     let mut router = wayfind::Router::new();
     for (index, route) in routes!(brackets).iter().enumerate() {
-        router.insert(route, index).unwrap();
+        router.insert(*route, index).unwrap();
     }
 
     bencher.bench(|| {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729850857,
-        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
+        "lastModified": 1729980323,
+        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
+        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729909612,
-        "narHash": "sha256-eXqxxbOagphPfjPptSlv0pQONB3fH15CQ4G8uCu1BW4=",
+        "lastModified": 1730082698,
+        "narHash": "sha256-xGP95+G2/esys6FpxrunwwfhirfGsFfPKBJ12MLV1Ps=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "17cadbc36da05e75197d082decb382a5f4208e30",
+        "rev": "0d594a39c8f08d81246d06a56e1ccfc04782404f",
         "type": "github"
       },
       "original": {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,9 @@ pub use insert::InsertError;
 pub(crate) mod path;
 pub use path::PathError;
 
+pub(crate) mod routable;
+pub use routable::RoutableError;
+
 pub(crate) mod route;
 pub use route::RouteError;
 

--- a/src/errors/routable.rs
+++ b/src/errors/routable.rs
@@ -1,0 +1,39 @@
+use std::{error::Error, fmt::Display};
+
+/// Errors that can occur when creating a [`Routable`](`crate::Routable`).
+#[derive(Debug, PartialEq, Eq)]
+pub enum RoutableError {
+    /// The route was not provided when building the [`Routable`](`crate::Routable`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::RoutableError;
+    ///
+    /// let error = RoutableError::MissingRoute;
+    ///
+    /// let display = "
+    /// missing route
+    ///
+    /// A route must be provided when building a Routable
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    MissingRoute,
+}
+
+impl Error for RoutableError {}
+
+impl Display for RoutableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingRoute => write!(
+                f,
+                r#"missing route
+
+A route must be provided when building a Routable"#
+            ),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,8 @@ pub use path::Path;
 
 pub(crate) mod parser;
 
+pub(crate) mod routable;
+pub use routable::{Routable, RoutableBuilder};
+
 pub(crate) mod router;
 pub use router::Router;

--- a/src/routable.rs
+++ b/src/routable.rs
@@ -1,0 +1,55 @@
+use crate::errors::RoutableError;
+
+/// A routable endpoint that can be inserted into a [`Router`](`crate::Router`).
+#[derive(Debug, Clone)]
+pub struct Routable<'a> {
+    pub(crate) route: &'a str,
+}
+
+impl<'a> Routable<'a> {
+    #[must_use]
+    pub const fn builder<'b>() -> RoutableBuilder<'b> {
+        RoutableBuilder::new()
+    }
+}
+
+impl<'a> From<&'a str> for Routable<'a> {
+    fn from(value: &'a str) -> Self {
+        Self { route: value }
+    }
+}
+
+/// Builder pattern for creating a [`Routable`].
+#[derive(Debug, Clone)]
+pub struct RoutableBuilder<'a> {
+    route: Option<&'a str>,
+}
+
+impl<'a> RoutableBuilder<'a> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { route: None }
+    }
+
+    #[must_use]
+    pub const fn route(mut self, route: &'a str) -> Self {
+        self.route = Some(route);
+        self
+    }
+
+    /// Builds a new [`Routable`] instance from the builder.
+    ///
+    /// # Errors
+    ///
+    /// Return a [`RoutableError`] if a required field was not populated.
+    pub fn build(self) -> Result<Routable<'a>, RoutableError> {
+        let route = self.route.ok_or(RoutableError::MissingRoute)?;
+        Ok(Routable { route })
+    }
+}
+
+impl<'a> Default for RoutableBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
We may be able to move more of the parsing logic (shared between insert + delete) to the routable method?

Would be nice to not need to clone here.

```rust
use wayfind::{Constraint, Router, Routable};

let mut router: Router<usize> = Router::new();

let route = Routable::builder()
    .route("/hello")
    .build()
    .unwrap();

router.insert(route.clone(), 1).unwrap();
router.delete(route).unwrap();
```

There's a decent about of duplicate code between insert + delete.

Would it be cheaper to clone the 'parsed' data for each insert/delete?

Doesn't need to be perfect - just need it in place before experimenting with method routing.