### PR TITLE
Convert prefix to a string.

### DIFF
--- a/examples/oci/src/router.rs
+++ b/examples/oci/src/router.rs
@@ -17,13 +17,13 @@ type ArcHandler = Arc<
         + Sync,
 >;
 
-pub struct AppRouter<'router> {
+pub struct AppRouter {
     /// Maps HTTP methods to their respective `wayfind` Routers.
     /// TODO: Replace with native `wayfind` method routing, when implemented.
-    routes: HashMap<Method, wayfind::Router<'router, ArcHandler>>,
+    routes: HashMap<Method, wayfind::Router<ArcHandler>>,
 }
 
-impl<'router> AppRouter<'router> {
+impl AppRouter {
     /// Creates a new `AppRouter` with empty route tables for all HTTP methods.
     #[must_use]
     pub fn new() -> Self {
@@ -56,7 +56,7 @@ impl<'router> AppRouter<'router> {
     }
 
     /// Adds a new route with the specified method, path, and handler.
-    pub fn route<H, T>(&mut self, method: Method, path: &'router str, handler: H)
+    pub fn route<H, T>(&mut self, method: Method, path: &str, handler: H)
     where
         H: Handler<T> + Send + Sync + 'static,
     {
@@ -115,7 +115,7 @@ impl<'router> AppRouter<'router> {
     }
 }
 
-impl<'router> Default for AppRouter<'router> {
+impl Default for AppRouter {
     fn default() -> Self {
         Self::new()
     }

--- a/src/errors/encoding.rs
+++ b/src/errors/encoding.rs
@@ -3,6 +3,40 @@ use std::{error::Error, fmt::Display};
 /// Errors relating to attempting to decode percent-encoded strings.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EncodingError {
+    // FIXME: Make this only take 1 input, turn key value to key:value ?
+    /// Invalid UTF-8 sequence encountered.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use wayfind::errors::EncodingError;
+    ///
+    /// let error = EncodingError::Utf8Error {
+    ///     key: "parameter".to_string(),
+    ///     value: "hello�world".to_string(),
+    /// };
+    ///
+    /// let display = "
+    /// invalid UTF-8 sequence
+    ///
+    ///      Key: parameter
+    ///    Value: hello�world
+    ///
+    /// Expected: valid UTF-8 characters
+    ///    Found: invalid byte sequence
+    /// ";
+    ///
+    /// assert_eq!(error.to_string(), display.trim());
+    /// ```
+    Utf8Error {
+        /// The parameter key.
+        /// This may contain UTF-8 replacement symbols.
+        key: String,
+        /// The parameter value.
+        /// This may contain UTF-8 replacement symbols.
+        value: String,
+    },
+
     /// Invalid percent-encoding sequence encountered.
     ///
     /// # Examples
@@ -73,6 +107,19 @@ impl Error for EncodingError {}
 impl Display for EncodingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Utf8Error { key, value } => {
+                write!(
+                    f,
+                    "invalid UTF-8 sequence
+
+     Key: {key}
+   Value: {value}
+
+Expected: valid UTF-8 characters
+   Found: invalid byte sequence",
+                )
+            }
+
             Self::InvalidEncoding {
                 input,
                 position,

--- a/src/errors/route.rs
+++ b/src/errors/route.rs
@@ -1,6 +1,11 @@
+use super::EncodingError;
+
 /// Errors relating to malformed routes.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RouteError {
+    /// A [`EncodingError`] that occurred during the decoding.
+    EncodingError(EncodingError),
+
     /// The route is empty.
     Empty,
 
@@ -359,6 +364,8 @@ impl std::error::Error for RouteError {}
 impl std::fmt::Display for RouteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::EncodingError(error) => error.fmt(f),
+
             Self::Empty => write!(f, "empty route"),
 
             Self::MissingLeadingSlash { route } => {
@@ -529,5 +536,11 @@ tip: Constraint names must not contain the characters: ':', '*', '{{', '}}', '('
                 )
             }
         }
+    }
+}
+
+impl From<EncodingError> for RouteError {
+    fn from(error: EncodingError) -> Self {
+        Self::EncodingError(error)
     }
 }

--- a/src/errors/search.rs
+++ b/src/errors/search.rs
@@ -1,40 +1,11 @@
+use super::EncodingError;
 use std::{error::Error, fmt::Display};
 
 /// Errors relating to attempting to search for a match in a [`Router`](crate::Router).
 #[derive(Debug, PartialEq, Eq)]
 pub enum SearchError {
-    /// Invalid UTF-8 sequence encountered.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use wayfind::errors::SearchError;
-    ///
-    /// let error = SearchError::Utf8Error {
-    ///     key: "parameter".to_string(),
-    ///     value: "hello�world".to_string(),
-    /// };
-    ///
-    /// let display = "
-    /// invalid UTF-8 sequence
-    ///
-    ///      Key: parameter
-    ///    Value: hello�world
-    ///
-    /// Expected: valid UTF-8 characters
-    ///    Found: invalid byte sequence
-    /// ";
-    ///
-    /// assert_eq!(error.to_string(), display.trim());
-    /// ```
-    Utf8Error {
-        /// The parameter key.
-        /// This may contain UTF-8 replacement symbols.
-        key: String,
-        /// The parameter value.
-        /// This may contain UTF-8 replacement symbols.
-        value: String,
-    },
+    /// A [`EncodingError`] that occurred during the decoding.
+    EncodingError(EncodingError),
 }
 
 impl Error for SearchError {}
@@ -42,18 +13,13 @@ impl Error for SearchError {}
 impl Display for SearchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Utf8Error { key, value } => {
-                write!(
-                    f,
-                    "invalid UTF-8 sequence
-
-     Key: {key}
-   Value: {value}
-
-Expected: valid UTF-8 characters
-   Found: invalid byte sequence",
-                )
-            }
+            Self::EncodingError(error) => error.fmt(f),
         }
+    }
+}
+
+impl From<EncodingError> for SearchError {
+    fn from(error: EncodingError) -> Self {
+        Self::EncodingError(error)
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,23 +12,23 @@ pub mod search;
 
 /// Represents a node in the tree structure.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Node<'router, T> {
+pub struct Node<T> {
     pub kind: Kind,
 
     /// The prefix may either be the static bytes of a path, or the name of a variable.
-    pub prefix: Vec<u8>,
+    pub prefix: String,
     /// Optional data associated with this node.
     /// The presence of this data is needed to successfully match a route.
-    pub data: Option<Data<'router, T>>,
+    pub data: Option<Data<T>>,
     /// An optional check to run, to restrict routing to this node.
-    pub constraint: Option<Vec<u8>>,
+    pub constraint: Option<String>,
 
-    pub static_children: Children<'router, T>,
-    pub dynamic_children: Children<'router, T>,
+    pub static_children: Children<T>,
+    pub dynamic_children: Children<T>,
     pub dynamic_children_shortcut: bool,
-    pub wildcard_children: Children<'router, T>,
+    pub wildcard_children: Children<T>,
     pub wildcard_children_shortcut: bool,
-    pub end_wildcard_children: Children<'router, T>,
+    pub end_wildcard_children: Children<T>,
 
     /// Higher values indicate more specific matches.
     pub priority: usize,
@@ -58,11 +58,11 @@ pub enum Kind {
 
 /// Holds data associated with a given node.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Data<'router, T> {
+pub enum Data<T> {
     /// Data is stored inline.
     Inline {
         /// The original route.
-        route: &'router str,
+        route: String,
 
         /// The associated data.
         value: T,
@@ -71,10 +71,10 @@ pub enum Data<'router, T> {
     /// Data is shared between 2 or more nodes.
     Shared {
         /// The original route.
-        route: &'router str,
+        route: String,
 
         /// The expanded route.
-        expanded: Arc<str>,
+        expanded: String,
 
         /// The associated data, shared.
         value: Arc<T>,
@@ -84,18 +84,18 @@ pub enum Data<'router, T> {
 /// A list of node children.
 /// Maintains whether it is sorted automatically.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Children<'router, T> {
-    nodes: Vec<Node<'router, T>>,
+pub struct Children<T> {
+    nodes: Vec<Node<T>>,
     sorted: bool,
 }
 
-impl<'router, T> Children<'router, T> {
-    fn push(&mut self, node: Node<'router, T>) {
+impl<T> Children<T> {
+    fn push(&mut self, node: Node<T>) {
         self.nodes.push(node);
         self.sorted = false;
     }
 
-    fn remove(&mut self, index: usize) -> Node<'router, T> {
+    fn remove(&mut self, index: usize) -> Node<T> {
         self.nodes.remove(index)
     }
 
@@ -118,23 +118,23 @@ impl<'router, T> Children<'router, T> {
         self.nodes.is_empty()
     }
 
-    fn find_mut<F>(&mut self, predicate: F) -> Option<&mut Node<'router, T>>
+    fn find_mut<F>(&mut self, predicate: F) -> Option<&mut Node<T>>
     where
-        F: Fn(&Node<'router, T>) -> bool,
+        F: Fn(&Node<T>) -> bool,
     {
         self.nodes.iter_mut().find(|node| predicate(node))
     }
 
-    fn iter(&self) -> impl Iterator<Item = &Node<'router, T>> {
+    fn iter(&self) -> impl Iterator<Item = &Node<T>> {
         self.nodes.iter()
     }
 
-    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Node<'router, T>> {
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Node<T>> {
         self.nodes.iter_mut()
     }
 }
 
-impl<'router, T> Default for Children<'router, T> {
+impl<T> Default for Children<T> {
     fn default() -> Self {
         Self {
             nodes: vec![],
@@ -143,8 +143,8 @@ impl<'router, T> Default for Children<'router, T> {
     }
 }
 
-impl<'router, T> From<Vec<Node<'router, T>>> for Children<'router, T> {
-    fn from(value: Vec<Node<'router, T>>) -> Self {
+impl<T> From<Vec<Node<T>>> for Children<T> {
+    fn from(value: Vec<Node<T>>) -> Self {
         Self {
             nodes: value,
             sorted: false,
@@ -152,15 +152,15 @@ impl<'router, T> From<Vec<Node<'router, T>>> for Children<'router, T> {
     }
 }
 
-impl<'router, T> Index<usize> for Children<'router, T> {
-    type Output = Node<'router, T>;
+impl<T> Index<usize> for Children<T> {
+    type Output = Node<T>;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.nodes[index]
     }
 }
 
-impl<'router, T> IndexMut<usize> for Children<'router, T> {
+impl<T> IndexMut<usize> for Children<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.nodes[index]
     }

--- a/src/node/delete.rs
+++ b/src/node/delete.rs
@@ -5,7 +5,7 @@ use crate::{
     parser::{Part, Route},
 };
 
-impl<'router, T> Node<'router, T> {
+impl<T> Node<T> {
     /// Deletes a route from the node tree.
     ///
     /// This method recursively traverses the tree to find and remove the specified route.
@@ -58,14 +58,19 @@ impl<'router, T> Node<'router, T> {
         &mut self,
         route: &mut Route,
         is_expanded: bool,
-        prefix: &[u8],
+        prefix: &str,
     ) -> Result<(), DeleteError> {
         let index = self
             .static_children
             .iter()
             .position(|child| {
                 prefix.len() >= child.prefix.len()
-                    && child.prefix.iter().zip(prefix).all(|(a, b)| a == b)
+                    && child
+                        .prefix
+                        .as_bytes()
+                        .iter()
+                        .zip(prefix.as_bytes())
+                        .all(|(a, b)| a == b)
             })
             .ok_or_else(|| DeleteError::NotFound {
                 route: String::from_utf8_lossy(&route.raw).to_string(),
@@ -94,8 +99,8 @@ impl<'router, T> Node<'router, T> {
         &mut self,
         route: &mut Route,
         is_expanded: bool,
-        name: &[u8],
-        constraint: &Option<Vec<u8>>,
+        name: &str,
+        constraint: &Option<String>,
     ) -> Result<(), DeleteError> {
         let index = self
             .dynamic_children
@@ -120,8 +125,8 @@ impl<'router, T> Node<'router, T> {
         &mut self,
         route: &mut Route,
         is_expanded: bool,
-        name: &[u8],
-        constraint: &Option<Vec<u8>>,
+        name: &str,
+        constraint: &Option<String>,
     ) -> Result<(), DeleteError> {
         let index = self
             .wildcard_children
@@ -145,8 +150,8 @@ impl<'router, T> Node<'router, T> {
     fn delete_end_wildcard(
         &mut self,
         route: &Route,
-        name: &[u8],
-        constraint: &Option<Vec<u8>>,
+        name: &str,
+        constraint: &Option<String>,
     ) -> Result<(), DeleteError> {
         let index = self
             .end_wildcard_children

--- a/src/node/display.rs
+++ b/src/node/display.rs
@@ -2,33 +2,26 @@ use super::Node;
 use crate::node::Kind;
 use std::fmt::{Display, Write};
 
-impl<'router, T> Display for Node<'router, T> {
+impl<T> Display for Node<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fn debug_node<T>(
             output: &mut String,
-            node: &Node<'_, T>,
+            node: &Node<T>,
             padding: &str,
             is_top: bool,
             is_last: bool,
         ) -> std::fmt::Result {
-            let constraint = node.constraint.as_ref().map(|c| String::from_utf8_lossy(c));
             let key = match &node.kind {
                 Kind::Root => unreachable!(),
-                Kind::Static => String::from_utf8_lossy(&node.prefix).to_string(),
-                Kind::Dynamic => {
-                    let name = String::from_utf8_lossy(&node.prefix);
-                    constraint.map_or_else(
-                        || format!("{{{name}}}"),
-                        |constraint| format!("{{{name}:{constraint}}}"),
-                    )
-                }
-                Kind::Wildcard | Kind::EndWildcard => {
-                    let name = String::from_utf8_lossy(&node.prefix);
-                    constraint.map_or_else(
-                        || format!("{{*{name}}}"),
-                        |constraint| format!("{{*{name}:{constraint}}}"),
-                    )
-                }
+                Kind::Static => node.prefix.clone(),
+                Kind::Dynamic => node.constraint.as_ref().map_or_else(
+                    || format!("{{{}}}", node.prefix),
+                    |constraint| format!("{{{}:{constraint}}}", node.prefix),
+                ),
+                Kind::Wildcard | Kind::EndWildcard => node.constraint.as_ref().map_or_else(
+                    || format!("{{*{}}}", node.prefix),
+                    |constraint| format!("{{*{}:{constraint}}}", node.prefix),
+                ),
             };
 
             if is_top {

--- a/src/node/optimize.rs
+++ b/src/node/optimize.rs
@@ -1,7 +1,7 @@
 use super::Data;
 use crate::node::Node;
 
-impl<'router, T> Node<'router, T> {
+impl<T> Node<T> {
     /// Re-optimizes the tree after an insert/delete.
     pub(crate) fn optimize(&mut self) {
         self.optimize_inner(0);
@@ -61,7 +61,7 @@ impl<'router, T> Node<'router, T> {
     fn update_dynamic_children_shortcut(&mut self) {
         self.dynamic_children_shortcut = self.dynamic_children.iter().all(|child| {
             // Leading slash?
-            if child.prefix.first() == Some(&b'/') {
+            if child.prefix.as_bytes().first() == Some(&b'/') {
                 return true;
             }
 
@@ -78,7 +78,7 @@ impl<'router, T> Node<'router, T> {
             if child
                 .static_children
                 .iter()
-                .all(|child| child.prefix.first() == Some(&b'/'))
+                .all(|child| child.prefix.as_bytes().first() == Some(&b'/'))
             {
                 return true;
             }
@@ -102,7 +102,7 @@ impl<'router, T> Node<'router, T> {
             if child
                 .static_children
                 .iter()
-                .all(|child| child.prefix.first() == Some(&b'/'))
+                .all(|child| child.prefix.as_bytes().first() == Some(&b'/'))
             {
                 return true;
             }

--- a/tests/constraints.rs
+++ b/tests/constraints.rs
@@ -190,7 +190,7 @@ impl Constraint for ConstraintB {
 
 #[test]
 fn constraint_duplicate_name_error() -> Result<(), Box<dyn Error>> {
-    let mut router: Router<'_, usize> = Router::new();
+    let mut router: Router<usize> = Router::new();
     router.constraint::<ConstraintA>()?;
 
     let error = router.constraint::<ConstraintB>().unwrap_err();

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -72,7 +72,7 @@ macro_rules! assert_router_matches {
 
 #[allow(clippy::missing_panics_doc)]
 pub fn assert_router_match<'a, T: PartialEq + Debug>(
-    router: &'a Router<'a, T>,
+    router: &'a Router<T>,
     input: &'a str,
     expected: Option<ExpectedMatch<'_, 'a, T>>,
 ) {


### PR DESCRIPTION
Seems faster locally.
Only doing UTF-8 checks once up-front.

Close to the sub 400ns/6ms barriers.

```
matchit/wayfind
  time:   [401.59 ns 402.36 ns 403.21 ns]

path-tree/wayfind
  time:   [6.1561 µs 6.1676 µs 6.1809 µs]
```

Should we then change our use of bytes to use chars instead too? 