### PR TITLE
Store path data within state via typestate. Remove kind enum.

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,14 +419,14 @@ In a router of 130 routes, benchmark matching 4 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 423.66 ns | 4           | 265 B      | 4             | 265 B        |
-| matchit          | 472.26 ns | 4           | 416 B      | 4             | 448 B        |
-| xitca-router     | 571.48 ns | 7           | 800 B      | 7             | 832 B        |
-| path-tree        | 585.17 ns | 4           | 416 B      | 4             | 448 B        |
-| ntex-router      | 1.7397 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
-| route-recognizer | 7.2323 µs | 160         | 8.505 KB   | 160           | 8.537 KB     |
-| routefinder      | 6.4459 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
-| actix-router     | 21.808 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
+| wayfind          | 391.25 ns | 4           | 265 B      | 4             | 265 B        |
+| matchit          | 478.77 ns | 4           | 416 B      | 4             | 448 B        |
+| xitca-router     | 574.55 ns | 7           | 800 B      | 7             | 832 B        |
+| path-tree        | 584.65 ns | 4           | 416 B      | 4             | 448 B        |
+| ntex-router      | 1.6921 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
+| route-recognizer | 4.6342 µs | 160         | 8.505 KB   | 160           | 8.537 KB     |
+| routefinder      | 6.4431 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
+| actix-router     | 20.879 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
 
 #### `path-tree` inspired benches
 
@@ -434,14 +434,14 @@ In a router of 320 routes, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 6.0964 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
-| path-tree        | 8.9851 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
-| matchit          | 10.520 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
-| xitca-router     | 10.899 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
-| ntex-router      | 29.300 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
-| route-recognizer | 92.872 µs | 2872        | 191.7 KB   | 2872          | 204.8 KB     |
-| routefinder      | 100.35 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
-| actix-router     | 180.80 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
+| wayfind          | 5.6689 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
+| path-tree        | 8.8896 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
+| matchit          | 9.0724 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
+| xitca-router     | 10.667 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
+| ntex-router      | 29.728 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
+| route-recognizer | 90.670 µs | 2872        | 191.7 KB   | 2872          | 204.8 KB     |
+| routefinder      | 100.01 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
+| actix-router     | 178.20 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
 
 ## License
 

--- a/src/errors/route.rs
+++ b/src/errors/route.rs
@@ -1,6 +1,11 @@
+use super::EncodingError;
+
 /// Errors relating to malformed routes.
 #[derive(Debug, PartialEq, Eq)]
 pub enum RouteError {
+    /// A [`EncodingError`] that occurred during the decoding.
+    EncodingError(EncodingError),
+
     /// The route is empty.
     Empty,
 
@@ -359,6 +364,7 @@ impl std::error::Error for RouteError {}
 impl std::fmt::Display for RouteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::EncodingError(error) => error.fmt(f),
             Self::Empty => write!(f, "empty route"),
 
             Self::MissingLeadingSlash { route } => {
@@ -529,5 +535,11 @@ tip: Constraint names must not contain the characters: ':', '*', '{{', '}}', '('
                 )
             }
         }
+    }
+}
+
+impl From<EncodingError> for RouteError {
+    fn from(error: EncodingError) -> Self {
+        Self::EncodingError(error)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,5 @@ pub use routable::{Routable, RoutableBuilder};
 
 pub(crate) mod router;
 pub use router::{Match, Parameter, Parameters, Router};
+
+pub(crate) mod state;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,3 +1,4 @@
+use crate::state::{DynamicState, EndWildcardState, State, StaticState, WildcardState};
 use std::{
     fmt::Debug,
     ops::{Index, IndexMut},
@@ -12,48 +13,25 @@ pub mod search;
 
 /// Represents a node in the tree structure.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Node<'r, T> {
-    pub kind: Kind,
+pub struct Node<'r, T, S: State> {
+    /// The type of Node, and associated structure data.
+    pub state: S,
 
-    /// The prefix may either be the static bytes of a path, or the name of a variable.
-    pub prefix: Vec<u8>,
     /// Optional data associated with this node.
     /// The presence of this data is needed to successfully match a route.
     pub data: Option<Data<'r, T>>,
-    /// An optional check to run, to restrict routing to this node.
-    pub constraint: Option<Vec<u8>>,
 
-    pub static_children: Children<'r, T>,
-    pub dynamic_children: Children<'r, T>,
+    pub static_children: Children<'r, T, StaticState>,
+    pub dynamic_children: Children<'r, T, DynamicState>,
     pub dynamic_children_shortcut: bool,
-    pub wildcard_children: Children<'r, T>,
+    pub wildcard_children: Children<'r, T, WildcardState>,
     pub wildcard_children_shortcut: bool,
-    pub end_wildcard_children: Children<'r, T>,
+    pub end_wildcard_children: Children<'r, T, EndWildcardState>,
 
     /// Higher values indicate more specific matches.
     pub priority: usize,
     /// Flag indicating whether this node or its children need optimization.
     pub needs_optimization: bool,
-}
-
-/// A node in the router tree structure.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Kind {
-    /// The root node of the tree.
-    /// Must only be used in the [`Router::new`](crate::Router::new) method.
-    Root,
-
-    /// A node with a fixed path segment.
-    Static,
-
-    /// A node that can match any bytes, excluding b'/'.
-    Dynamic,
-
-    /// A node that can match any bytes, including b'/'.
-    Wildcard,
-
-    /// A node that matches the whole remaining path.
-    EndWildcard,
 }
 
 /// Holds data associated with a given node.
@@ -84,21 +62,42 @@ pub enum Data<'r, T> {
 /// A list of node children.
 /// Maintains whether it is sorted automatically.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Children<'r, T> {
-    nodes: Vec<Node<'r, T>>,
+pub struct Children<'r, T, S: State> {
+    nodes: Vec<Node<'r, T, S>>,
     sorted: bool,
 }
 
-impl<'r, T> Children<'r, T> {
-    fn push(&mut self, node: Node<'r, T>) {
+impl<'r, T, S: State> Children<'r, T, S> {
+    fn push(&mut self, node: Node<'r, T, S>) {
         self.nodes.push(node);
         self.sorted = false;
     }
 
-    fn remove(&mut self, index: usize) -> Node<'r, T> {
+    fn remove(&mut self, index: usize) -> Node<'r, T, S> {
         self.nodes.remove(index)
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    fn find_mut<F>(&mut self, predicate: F) -> Option<&mut Node<'r, T, S>>
+    where
+        F: Fn(&Node<'r, T, S>) -> bool,
+    {
+        self.nodes.iter_mut().find(|node| predicate(node))
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Node<'r, T, S>> {
+        self.nodes.iter()
+    }
+
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Node<'r, T, S>> {
+        self.nodes.iter_mut()
+    }
+}
+
+impl<'r, T, S: State + Ord> Children<'r, T, S> {
     fn sort(&mut self) {
         if self.sorted {
             return;
@@ -107,44 +106,24 @@ impl<'r, T> Children<'r, T> {
         self.nodes.sort_by(|a, b| {
             b.priority
                 .cmp(&a.priority)
-                .then_with(|| a.prefix.cmp(&b.prefix))
-                .then_with(|| a.constraint.cmp(&b.constraint))
+                .then_with(|| a.state.cmp(&b.state))
         });
 
         self.sorted = true;
     }
-
-    fn is_empty(&self) -> bool {
-        self.nodes.is_empty()
-    }
-
-    fn find_mut<F>(&mut self, predicate: F) -> Option<&mut Node<'r, T>>
-    where
-        F: Fn(&Node<'r, T>) -> bool,
-    {
-        self.nodes.iter_mut().find(|node| predicate(node))
-    }
-
-    fn iter(&self) -> impl Iterator<Item = &Node<'r, T>> {
-        self.nodes.iter()
-    }
-
-    fn iter_mut(&mut self) -> impl Iterator<Item = &mut Node<'r, T>> {
-        self.nodes.iter_mut()
-    }
 }
 
-impl<'r, T> Default for Children<'r, T> {
+impl<'r, T, S: State> Default for Children<'r, T, S> {
     fn default() -> Self {
         Self {
             nodes: vec![],
-            sorted: true,
+            sorted: false,
         }
     }
 }
 
-impl<'r, T> From<Vec<Node<'r, T>>> for Children<'r, T> {
-    fn from(value: Vec<Node<'r, T>>) -> Self {
+impl<'r, T, S: State> From<Vec<Node<'r, T, S>>> for Children<'r, T, S> {
+    fn from(value: Vec<Node<'r, T, S>>) -> Self {
         Self {
             nodes: value,
             sorted: false,
@@ -152,15 +131,15 @@ impl<'r, T> From<Vec<Node<'r, T>>> for Children<'r, T> {
     }
 }
 
-impl<'r, T> Index<usize> for Children<'r, T> {
-    type Output = Node<'r, T>;
+impl<'r, T, S: State> Index<usize> for Children<'r, T, S> {
+    type Output = Node<'r, T, S>;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.nodes[index]
     }
 }
 
-impl<'r, T> IndexMut<usize> for Children<'r, T> {
+impl<'r, T, S: State> IndexMut<usize> for Children<'r, T, S> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.nodes[index]
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,272 @@
+use std::cmp::Ordering;
+
+pub trait State {
+    fn priority(&self) -> usize;
+    fn padding(&self) -> usize;
+    fn key(&self) -> &str;
+}
+
+/// Root node state
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RootState {
+    priority: usize,
+    padding: usize,
+    key: String,
+}
+
+impl RootState {
+    pub const fn new() -> Self {
+        Self {
+            priority: 0,
+            padding: 0,
+            key: String::new(),
+        }
+    }
+}
+
+impl State for RootState {
+    fn priority(&self) -> usize {
+        self.priority
+    }
+
+    fn padding(&self) -> usize {
+        self.padding
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+/// Static path segment state
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StaticState {
+    pub prefix: Vec<u8>,
+    priority: usize,
+    padding: usize,
+    key: String,
+}
+
+impl StaticState {
+    pub fn new(prefix: Vec<u8>) -> Self {
+        let priority = prefix.len();
+        let padding = prefix.len().saturating_sub(1);
+        let key = String::from_utf8_lossy(&prefix).into_owned();
+
+        Self {
+            prefix,
+            priority,
+            padding,
+            key,
+        }
+    }
+}
+
+impl State for StaticState {
+    fn priority(&self) -> usize {
+        self.priority
+    }
+
+    fn padding(&self) -> usize {
+        self.padding
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+impl Ord for StaticState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.prefix.cmp(&other.prefix)
+    }
+}
+
+impl PartialOrd for StaticState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Dynamic parameter state
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DynamicState {
+    pub name: String,
+    pub constraint: Option<String>,
+    priority: usize,
+    padding: usize,
+    key: String,
+}
+
+impl DynamicState {
+    pub fn new(name: String, constraint: Option<String>) -> Self {
+        let mut priority = name.len();
+        if constraint.is_some() {
+            priority += 10_000;
+        }
+
+        let padding = name.len().saturating_sub(1);
+        let key = constraint.as_ref().map_or_else(
+            || format!("{{{name}}}"),
+            |constraint| format!("{{{name}:{constraint}}}"),
+        );
+
+        Self {
+            name,
+            constraint,
+            priority,
+            padding,
+            key,
+        }
+    }
+}
+
+impl State for DynamicState {
+    fn priority(&self) -> usize {
+        self.priority
+    }
+
+    fn padding(&self) -> usize {
+        self.padding
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+impl Ord for DynamicState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.constraint.cmp(&other.constraint))
+    }
+}
+
+impl PartialOrd for DynamicState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Wildcard state that can match across path segments
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WildcardState {
+    pub name: String,
+    pub constraint: Option<String>,
+    priority: usize,
+    padding: usize,
+    key: String,
+}
+
+impl WildcardState {
+    pub fn new(name: String, constraint: Option<String>) -> Self {
+        let mut priority = name.len();
+        if constraint.is_some() {
+            priority += 10_000;
+        }
+
+        let padding = name.len().saturating_sub(1);
+        let key = constraint.as_ref().map_or_else(
+            || format!("{{*{name}}}"),
+            |constraint| format!("{{*{name}:{constraint}}}"),
+        );
+
+        Self {
+            name,
+            constraint,
+            priority,
+            padding,
+            key,
+        }
+    }
+}
+
+impl State for WildcardState {
+    fn priority(&self) -> usize {
+        self.priority
+    }
+
+    fn padding(&self) -> usize {
+        self.padding
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+impl Ord for WildcardState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.constraint.cmp(&other.constraint))
+    }
+}
+
+impl PartialOrd for WildcardState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// End wildcard state that matches remaining path
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EndWildcardState {
+    pub name: String,
+    pub constraint: Option<String>,
+    priority: usize,
+    padding: usize,
+    key: String,
+}
+
+impl EndWildcardState {
+    pub fn new(name: String, constraint: Option<String>) -> Self {
+        let mut priority = name.len();
+        if constraint.is_some() {
+            priority += 10_000;
+        }
+
+        let padding = name.len().saturating_sub(1);
+        let key = constraint.as_ref().map_or_else(
+            || format!("{{*{name}}}"),
+            |constraint| format!("{{*{name}:{constraint}}}"),
+        );
+
+        Self {
+            name,
+            constraint,
+            priority,
+            padding,
+            key,
+        }
+    }
+}
+
+impl State for EndWildcardState {
+    fn priority(&self) -> usize {
+        self.priority
+    }
+
+    fn padding(&self) -> usize {
+        self.padding
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+impl Ord for EndWildcardState {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.constraint.cmp(&other.constraint))
+    }
+}
+
+impl PartialOrd for EndWildcardState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}


### PR DESCRIPTION
Lots of messy unreachables - would be nice to make those states unrepresentable.

Allows us to guarantee the dynamic/wildcard names are valid UTF-8 at insert time.

If we keep working on this - I think it could be more ergonomic too.

UPDATE: Tried typestate pattern.

Performance seems better locally. Under the 400ns barrier on a good run locally.

Since we've moved more logic to the insert stage, some benches are "failing". But a worthwhile tradeoff.