### PR TITLE
Add support for WASM

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,53 @@
+name: wasm
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_VERSION: "1"
+
+jobs:
+  wasm:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        shell: nix develop .#wasm --command bash {0}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Configure SCCache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL);
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN);
+
+      - name: Initialize Nix shell
+        run: nix develop .#wasm
+
+      - name: Build wayfind
+        run: cargo build
+
+      - name: Show SCCache stats
+        if: always() && !cancelled()
+        run: sccache --show-stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for `#[no_std]` builds (with alloc).
+- Support for WASM builds.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+![license: MIT/Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)
 [![crates.io](https://img.shields.io/crates/v/wayfind)](https://crates.io/crates/wayfind)
 [![documentation](https://docs.rs/wayfind/badge.svg)](https://docs.rs/wayfind)
+
 ![rust: 1.81+](https://img.shields.io/badge/rust-1.81+-orange.svg)
-![unsafe: forbidden](https://img.shields.io/badge/unsafe-forbidden-brightgreen.svg)
+![`unsafe`: forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)
 ![`no_std`: compatible](https://img.shields.io/badge/no__std-compatible-success.svg)
-![license: MIT/Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)
+![`wasm`: compatible](https://img.shields.io/badge/wasm-compatible-success.svg)
 
 [![codspeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DuskSystems/wayfind)
 [![codecov](https://codecov.io/gh/DuskSystems/wayfind/graph/badge.svg?token=QMSW55438K)](https://codecov.io/gh/DuskSystems/wayfind)

--- a/flake.nix
+++ b/flake.nix
@@ -215,6 +215,22 @@
             ];
           };
 
+          # nix develop .#wasm
+          wasm = pkgs.mkShell {
+            name = "wayfind-wasm-shell";
+
+            RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
+            CARGO_INCREMENTAL = "0";
+            CARGO_BUILD_TARGET = "wasm32-unknown-unknown";
+
+            buildInputs = with pkgs; [
+              (rust-bin.stable."1.81.0".minimal.override {
+                targets = [ "wasm32-unknown-unknown" ];
+              })
+              sccache
+            ];
+          };
+
           # nix develop .#oci
           oci = pkgs.mkShell {
             name = "wayfind-oci-shell";


### PR DESCRIPTION
Would prefer to actually create examples showcasing this, but a successful build is good enough for now. Maybe we could build and run our OCI example?

EDIT: Need to refactor our CI. Benchmark build isn't being cached. Maybe use cachix? Also - so much duplication. Could use Cachix for Nix, keep GH cache for sccache?