### PR TITLE
Introduce route ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,14 +512,14 @@ In a router of 130 routes, benchmark matching 4 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 325.41 ns | 4           | 265 B      | 4             | 265 B        |
-| matchit          | 366.66 ns | 4           | 416 B      | 4             | 448 B        |
-| xitca-router     | 409.16 ns | 7           | 800 B      | 7             | 832 B        |
-| path-tree        | 430.49 ns | 4           | 416 B      | 4             | 448 B        |
-| ntex-router      | 1.7411 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
-| route-recognizer | 2.0456 µs | 160         | 8.505 KB   | 160           | 8.537 KB     |
-| routefinder      | 4.7301 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
-| actix-router     | 17.656 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
+| wayfind          | 328.25 ns | 4           | 265 B      | 4             | 265 B        |
+| matchit          | 364.79 ns | 4           | 416 B      | 4             | 448 B        |
+| xitca-router     | 407.60 ns | 7           | 800 B      | 7             | 832 B        |
+| path-tree        | 429.00 ns | 4           | 416 B      | 4             | 448 B        |
+| ntex-router      | 1.7253 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
+| route-recognizer | 2.0428 µs | 160         | 8.505 KB   | 160           | 8.537 KB     |
+| routefinder      | 4.7254 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
+| actix-router     | 17.780 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
 
 #### `path-tree` inspired benches
 
@@ -527,14 +527,14 @@ In a router of 320 routes, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 4.6853 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
-| matchit          | 6.3997 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
-| path-tree        | 7.0728 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
-| xitca-router     | 7.7275 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
-| ntex-router      | 31.155 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
-| route-recognizer | 54.925 µs | 2872        | 191.7 KB   | 2872          | 204.8 KB     |
-| routefinder      | 75.759 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
-| actix-router     | 148.91 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
+| wayfind          | 4.6957 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
+| matchit          | 6.7463 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
+| path-tree        | 7.1253 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
+| xitca-router     | 7.5683 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
+| ntex-router      | 31.163 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
+| route-recognizer | 54.888 µs | 2872        | 191.7 KB   | 2872          | 204.8 KB     |
+| routefinder      | 75.574 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
+| actix-router     | 150.25 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
 
 ## License
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,19 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+static ID: AtomicUsize = AtomicUsize::new(0);
+
+/// A unique ID for a route within the router.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RouteId(usize);
+
+impl RouteId {
+    pub fn new() -> Self {
+        Self(ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl Default for RouteId {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub(crate) mod decode;
 
 pub mod errors;
 
+pub(crate) mod id;
+
 pub(crate) mod node;
 
 pub(crate) mod parser;
@@ -24,3 +26,5 @@ pub(crate) mod router;
 pub use router::{Match, Parameters, Router};
 
 pub(crate) mod state;
+
+pub(crate) mod storage;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,7 @@
-use crate::state::{DynamicState, EndWildcardState, State, StaticState, WildcardState};
+use crate::{
+    state::{DynamicState, EndWildcardState, State, StaticState, WildcardState},
+    storage::Storage,
+};
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{
     fmt::Debug,
@@ -43,7 +46,7 @@ pub enum Data<'r, T> {
         route: &'r str,
 
         /// The associated data.
-        value: T,
+        storage: Storage<T>,
     },
 
     /// Data is shared between 2 or more nodes.
@@ -55,7 +58,7 @@ pub enum Data<'r, T> {
         expanded: Arc<str>,
 
         /// The associated data, shared.
-        value: Arc<T>,
+        storage: Arc<Storage<T>>,
     },
 }
 

--- a/src/routable.rs
+++ b/src/routable.rs
@@ -1,6 +1,7 @@
 use crate::{
     decode::percent_decode,
     errors::{EncodingError, RoutableError},
+    storage::StorageKind,
 };
 use alloc::{
     borrow::ToOwned,
@@ -11,6 +12,7 @@ use alloc::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Routable<'r> {
     pub(crate) route: &'r str,
+    pub storage: StorageKind,
 }
 
 /// Builder pattern for creating a [`Routable`].
@@ -47,7 +49,10 @@ impl<'r> RoutableBuilder<'r> {
             })?;
         }
 
-        Ok(Routable { route })
+        Ok(Routable {
+            route,
+            storage: StorageKind::Inline,
+        })
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,14 @@
+use crate::id::RouteId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageKind {
+    Inline,
+    Router,
+}
+
+/// Where the route data is stored.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Storage<T> {
+    Inline(T),
+    Router(RouteId),
+}


### PR DESCRIPTION
At the request builder level - we can determine whether we need to store the data inline or at the router.

Then within the path insert, we would decide if the inline would be direct or shared.

Same for all other routers.

Still slower locally. But will always be due to the additional hashmap lookup.

```
matchit benchmarks/wayfind
    time:   [350.76 ns 351.30 ns 351.89 ns] (+8%)
path-tree benchmarks/wayfind
    time:   [5.0726 µs 5.0812 µs 5.0921 µs] (+5%)
```

Just need this in place - shouldn't actually make use of it yet.

UPDATE: Managed to get the impact to essentially 0%. We don't actually make use of the ID yet - but all the logic is in place for it.