### PR TITLE
Tweak release profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ str_to_string = "deny"
 insta.opt-level = 3
 similar.opt-level = 3
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/README.md
+++ b/README.md
@@ -490,14 +490,14 @@ In a router of 130 routes, benchmark matching 4 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 386.64 ns | 4           | 265 B      | 4             | 265 B        |
-| matchit          | 477.13 ns | 4           | 416 B      | 4             | 448 B        |
-| xitca-router     | 557.61 ns | 7           | 800 B      | 7             | 832 B        |
-| path-tree        | 574.68 ns | 4           | 416 B      | 4             | 448 B        |
-| ntex-router      | 1.7266 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
-| route-recognizer | 4.7007 µs | 160         | 8.505 KB   | 160           | 8.537 KB     |
-| routefinder      | 6.4120 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
-| actix-router     | 20.772 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
+| wayfind          | 384.74 ns | 4           | 265 B      | 4             | 265 B        |
+| matchit          | 440.53 ns | 4           | 416 B      | 4             | 448 B        |
+| path-tree        | 517.08 ns | 4           | 416 B      | 4             | 448 B        |
+| xitca-router     | 527.06 ns | 7           | 800 B      | 7             | 832 B        |
+| ntex-router      | 1.9893 µs | 18          | 1.248 KB   | 18            | 1.28 KB      |
+| route-recognizer | 4.1686 µs | 160         | 8.505 KB   | 160           | 8.537 KB     |
+| routefinder      | 5.4922 µs | 67          | 5.024 KB   | 67            | 5.056 KB     |
+| actix-router     | 20.502 µs | 214         | 13.93 KB   | 214           | 13.96 KB     |
 
 #### `path-tree` inspired benches
 
@@ -505,14 +505,14 @@ In a router of 320 routes, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 5.7497 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
-| path-tree        | 8.9033 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
-| matchit          | 9.0204 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
-| xitca-router     | 10.782 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
-| ntex-router      | 29.200 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
-| route-recognizer | 90.893 µs | 2872        | 191.7 KB   | 2872          | 204.8 KB     |
-| routefinder      | 100.36 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
-| actix-router     | 175.23 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
+| wayfind          | 5.5736 µs | 59          | 2.567 KB   | 59            | 2.567 KB     |
+| path-tree        | 7.9324 µs | 59          | 7.447 KB   | 59            | 7.47 KB      |
+| matchit          | 8.5009 µs | 140         | 17.81 KB   | 140           | 17.83 KB     |
+| xitca-router     | 10.296 µs | 209         | 25.51 KB   | 209           | 25.53 KB     |
+| ntex-router      | 33.301 µs | 201         | 19.54 KB   | 201           | 19.56 KB     |
+| routefinder      | 81.328 µs | 525         | 48.4 KB    | 525           | 48.43 KB     |
+| route-recognizer | 86.906 µs | 2872        | 191.7 KB   | 2872          | 204.8 KB     |
+| actix-router     | 172.28 µs | 2201        | 128.8 KB   | 2201          | 128.8 KB     |
 
 ## License
 

--- a/nix/vm.nix
+++ b/nix/vm.nix
@@ -62,11 +62,14 @@
     defaultPackages = with pkgs; [
       gcc
       (rust-bin.stable."1.82.0".minimal)
+      sccache
       gnuplot
     ];
 
     variables = {
+      RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
       RUSTFLAGS = "-C target-cpu=native";
+      CARGO_INCREMENTAL = "0";
       CARGO_TARGET_DIR = "/tmp";
     };
 


### PR DESCRIPTION
No improvement natively, but performs better inside the VM.

```
path-tree benchmarks/path-tree benchmarks/wayfind
                        time:   [5.0600 µs 5.0699 µs 5.0828 µs]
                        change: [-6.9033% -6.6107% -6.3174%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe
path-tree benchmarks/path-tree benchmarks/actix-router
                        time:   [187.47 µs 187.82 µs 188.20 µs]
                        change: [-17.174% -16.167% -15.051%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
path-tree benchmarks/path-tree benchmarks/matchit
                        time:   [9.5411 µs 9.5532 µs 9.5658 µs]
                        change: [-20.179% -19.354% -18.761%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  6 (6.00%) high severe
path-tree benchmarks/path-tree benchmarks/ntex-router
                        time:   [35.458 µs 35.529 µs 35.623 µs]
                        change: [+2.0924% +2.7236% +3.5443%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
path-tree benchmarks/path-tree benchmarks/path-tree
                        time:   [8.4842 µs 8.4942 µs 8.5048 µs]
                        change: [-11.373% -10.827% -10.345%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
path-tree benchmarks/path-tree benchmarks/route-recognizer
                        time:   [67.237 µs 67.379 µs 67.542 µs]
                        change: [-19.891% -19.500% -19.098%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
path-tree benchmarks/path-tree benchmarks/routefinder
                        time:   [85.861 µs 85.957 µs 86.068 µs]
                        change: [-21.068% -20.803% -20.542%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
path-tree benchmarks/path-tree benchmarks/xitca-router
                        time:   [11.722 µs 11.738 µs 11.754 µs]
                        change: [-4.5687% -4.2041% -3.8165%] (p = 0.00 < 0.05)
                        Performance has improved.
```

ntex-router the only outlier.