### PR TITLE
Update matchit benchmarks to v0.8.6

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -23,18 +23,18 @@ All routers provide a way to return parameters as strings, but some delay the ac
 
 ## `matchit` inspired benches
 
-In a router of 130 templates, benchmark matching 4 paths.
+In a router of 130 templates, benchmark matching 130 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 275.01 ns | 4           | 288 B      | 4             | 288 B        |
-| matchit          | 364.81 ns | 4           | 448 B      | 4             | 448 B        |
-| path-tree        | 395.96 ns | 4           | 448 B      | 4             | 448 B        |
-| xitca-router     | 481.10 ns | 7           | 832 B      | 7             | 832 B        |
-| ntex-router      | 1.9415 µs | 18          | 1.28 KB    | 18            | 1.28 KB      |
-| route-recognizer | 2.7512 µs | 160         | 8.537 KB   | 160           | 8.537 KB     |
-| routefinder      | 5.7934 µs | 67          | 5.056 KB   | 67            | 5.056 KB     |
-| actix-router     | 19.585 µs | 214         | 13.96 KB   | 214           | 13.96 KB     |
+| wayfind          | 7.7684 µs | 4           | 288 B      | 4             | 288 B        |
+| matchit          | 11.555 µs | 4           | 448 B      | 4             | 448 B        |
+| path-tree        | 12.479 µs | 4           | 448 B      | 4             | 448 B        |
+| xitca-router     | 14.823 µs | 7           | 832 B      | 7             | 832 B        |
+| ntex-router      | 51.490 µs | 18          | 1.28 KB    | 18            | 1.28 KB      |
+| route-recognizer | 69.752 µs | 160         | 8.537 KB   | 160           | 8.537 KB     |
+| routefinder      | 173.13 µs | 67          | 5.056 KB   | 67            | 5.056 KB     |
+| actix-router     | 513.33 µs | 214         | 13.96 KB   | 214           | 13.96 KB     |
 
 ## `path-tree` inspired benches
 
@@ -42,14 +42,14 @@ In a router of 320 templates, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 4.2122 µs | 59          | 3.808 KB   | 59            | 3.808 KB     |
-| path-tree        | 6.4776 µs | 59          | 8.704 KB   | 59            | 8.704 KB     |
-| matchit          | 7.7900 µs | 140         | 19.07 KB   | 140           | 19.07 KB     |
-| xitca-router     | 9.3764 µs | 209         | 26.77 KB   | 209           | 26.77 KB     |
-| ntex-router      | 32.275 µs | 201         | 20.8 KB    | 201           | 20.8 KB      |
-| route-recognizer | 63.003 µs | 2872        | 192.9 KB   | 2872          | 206.1 KB     |
-| routefinder      | 80.219 µs | 525         | 49.66 KB   | 525           | 49.66 KB     |
-| actix-router     | 175.23 µs | 2201        | 130.1 KB   | 2201          | 130.1 KB     |
+| wayfind          | 3.9816 µs | 59          | 3.808 KB   | 59            | 3.808 KB     |
+| path-tree        | 6.5198 µs | 59          | 8.704 KB   | 59            | 8.704 KB     |
+| matchit          | 7.8498 µs | 140         | 19.07 KB   | 140           | 19.07 KB     |
+| xitca-router     | 9.4876 µs | 209         | 26.77 KB   | 209           | 26.77 KB     |
+| ntex-router      | 32.175 µs | 201         | 20.8 KB    | 201           | 20.8 KB      |
+| route-recognizer | 62.862 µs | 2872        | 192.9 KB   | 2872          | 206.1 KB     |
+| routefinder      | 80.606 µs | 525         | 49.66 KB   | 525           | 49.66 KB     |
+| actix-router     | 175.21 µs | 2201        | 130.1 KB   | 2201          | 130.1 KB     |
 
 ## `wayfind` benches
 

--- a/benches/matchit_criterion.rs
+++ b/benches/matchit_criterion.rs
@@ -1,8 +1,7 @@
 //! Benches sourced from `matchit` (MIT AND BSD-3-Clause)
-//! <https://github.com/ibraheemdev/matchit/blob/v0.8.5/benches/bench.rs>
+//! <https://github.com/ibraheemdev/matchit/blob/v0.8.6/benches/bench.rs>
 
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
-use matchit_routes::paths;
 
 pub mod matchit_routes;
 
@@ -23,7 +22,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let output = black_box(router.search(black_box(path)).unwrap());
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.parameters.iter().map(|p| (p.0, p.1)).collect());
@@ -39,7 +38,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         let router = router.finish();
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let mut path = actix_router::Path::new(path);
                 black_box(router.recognize(black_box(&mut path)).unwrap());
                 let _parameters: Vec<(&str, &str)> =
@@ -55,7 +54,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let output = black_box(router.at(black_box(path)).unwrap());
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.params.iter().map(|p| (p.0, p.1)).collect());
@@ -71,7 +70,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         let router = router.finish();
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let mut path = ntex_router::Path::new(path);
                 router.recognize(&mut path).unwrap();
                 let _parameters: Vec<(&str, &str)> =
@@ -87,7 +86,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let output = router.find(path).unwrap();
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.1.params_iter().map(|p| (p.0, p.1)).collect());
@@ -102,7 +101,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let output = router.recognize(path).unwrap();
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.params().iter().map(|p| (p.0, p.1)).collect());
@@ -117,7 +116,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let output = router.best_match(path).unwrap();
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.captures().iter().map(|p| (p.0, p.1)).collect());
@@ -132,7 +131,7 @@ fn matchit_benchmark(criterion: &mut Criterion) {
         }
 
         bencher.iter(|| {
-            for path in black_box(paths()) {
+            for path in black_box(routes!(literal)) {
                 let output = router.at(path).unwrap();
                 let _parameters: Vec<(&str, &str)> =
                     black_box(output.params.iter().map(|p| (p.0, p.1)).collect());

--- a/benches/matchit_divan.rs
+++ b/benches/matchit_divan.rs
@@ -1,9 +1,8 @@
 //! Benches sourced from `matchit` (MIT AND BSD-3-Clause)
-//! <https://github.com/ibraheemdev/matchit/blob/v0.8.5/benches/bench.rs>
+//! <https://github.com/ibraheemdev/matchit/blob/v0.8.6/benches/bench.rs>
 
 use codspeed_criterion_compat::black_box;
 use divan::AllocProfiler;
-use matchit_routes::paths;
 
 pub mod matchit_routes;
 
@@ -17,12 +16,13 @@ fn main() {
 #[divan::bench(name = "wayfind")]
 fn wayfind(bencher: divan::Bencher<'_, '_>) {
     let mut router = wayfind::Router::new();
+
     for route in routes!(brackets) {
         router.insert(route, true).unwrap();
     }
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let output = black_box(router.search(black_box(path)).unwrap());
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.parameters.iter().map(|p| (p.0, p.1)).collect());
@@ -39,7 +39,7 @@ fn actix_router(bencher: divan::Bencher<'_, '_>) {
     let router = router.finish();
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let mut path = actix_router::Path::new(path);
             black_box(router.recognize(black_box(&mut path)).unwrap());
             let _parameters: Vec<(&str, &str)> =
@@ -56,7 +56,7 @@ fn matchit(bencher: divan::Bencher<'_, '_>) {
     }
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let output = black_box(router.at(black_box(path)).unwrap());
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.params.iter().map(|p| (p.0, p.1)).collect());
@@ -73,7 +73,7 @@ fn ntex_router(bencher: divan::Bencher<'_, '_>) {
     let router = router.finish();
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let mut path = ntex_router::Path::new(path);
             router.recognize(&mut path).unwrap();
             let _parameters: Vec<(&str, &str)> =
@@ -90,7 +90,7 @@ fn path_tree(bencher: divan::Bencher<'_, '_>) {
     }
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let output = router.find(path).unwrap();
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.1.params_iter().map(|p| (p.0, p.1)).collect());
@@ -106,7 +106,7 @@ fn route_recognizer(bencher: divan::Bencher<'_, '_>) {
     }
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let output = router.recognize(path).unwrap();
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.params().iter().map(|p| (p.0, p.1)).collect());
@@ -122,7 +122,7 @@ fn routefinder(bencher: divan::Bencher<'_, '_>) {
     }
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let output = router.best_match(path).unwrap();
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.captures().iter().map(|p| (p.0, p.1)).collect());
@@ -138,7 +138,7 @@ fn xitca_router(bencher: divan::Bencher<'_, '_>) {
     }
 
     bencher.bench(|| {
-        for path in black_box(paths()) {
+        for path in black_box(routes!(literal)) {
             let output = router.at(path).unwrap();
             let _parameters: Vec<(&str, &str)> =
                 black_box(output.params.iter().map(|p| (p.0, p.1)).collect());

--- a/benches/matchit_routes.rs
+++ b/benches/matchit_routes.rs
@@ -1,15 +1,9 @@
-#[must_use]
-pub fn paths() -> impl IntoIterator<Item = &'static str> {
-    vec![
-        "/user/repos",
-        "/repos/rust-lang/rust/stargazers",
-        "/orgs/rust-lang/public_members/nikomatsakis",
-        "/repos/rust-lang/rust/releases/1.51.0",
-    ]
-}
-
 #[macro_export]
 macro_rules! routes {
+    (literal) => {{
+        routes!(finish => "p1", "p2", "p3", "p4")
+    }};
+
     (colon) => {{
         routes!(finish => ":p1", ":p2", ":p3", ":p4")
     }};
@@ -79,13 +73,13 @@ macro_rules! routes {
             concat!("/user/orgs"),
             concat!("/orgs/", $p1),
             concat!("/orgs/", $p1, "/members"),
-            concat!("/orgs/", $p1, "/members", $p2),
+            concat!("/orgs/", $p1, "/members/", $p2),
             concat!("/orgs/", $p1, "/public_members"),
             concat!("/orgs/", $p1, "/public_members/", $p2),
             concat!("/orgs/", $p1, "/teams"),
             concat!("/teams/", $p1),
             concat!("/teams/", $p1, "/members"),
-            concat!("/teams/", $p1, "/members", $p2),
+            concat!("/teams/", $p1, "/members/", $p2),
             concat!("/teams/", $p1, "/repos"),
             concat!("/teams/", $p1, "/repos/", $p2, "/", $p3),
             concat!("/user/teams"),
@@ -114,12 +108,12 @@ macro_rules! routes {
             concat!("/repos/", $p1, "/", $p2, "/commits/", $p3),
             concat!("/repos/", $p1, "/", $p2, "/readme"),
             concat!("/repos/", $p1, "/", $p2, "/keys"),
-            concat!("/repos/", $p1, "/", $p2, "/keys", $p3),
+            concat!("/repos/", $p1, "/", $p2, "/keys/", $p3),
             concat!("/repos/", $p1, "/", $p2, "/downloads"),
-            concat!("/repos/", $p1, "/", $p2, "/downloads", $p3),
+            concat!("/repos/", $p1, "/", $p2, "/downloads/", $p3),
             concat!("/repos/", $p1, "/", $p2, "/forks"),
             concat!("/repos/", $p1, "/", $p2, "/hooks"),
-            concat!("/repos/", $p1, "/", $p2, "/hooks", $p3),
+            concat!("/repos/", $p1, "/", $p2, "/hooks/", $p3),
             concat!("/repos/", $p1, "/", $p2, "/releases"),
             concat!("/repos/", $p1, "/", $p2, "/releases/", $p3),
             concat!("/repos/", $p1, "/", $p2, "/releases/", $p3, "/assets"),
@@ -146,7 +140,7 @@ macro_rules! routes {
             concat!("/users/", $p1, "/following"),
             concat!("/user/following"),
             concat!("/user/following/", $p1),
-            concat!("/users/", $p1, "/following", $p2),
+            concat!("/users/", $p1, "/following/", $p2),
             concat!("/users/", $p1, "/keys"),
             concat!("/user/keys"),
             concat!("/user/keys/", $p1),

--- a/src/node/search.rs
+++ b/src/node/search.rs
@@ -16,7 +16,7 @@ impl<'r, T, S: NodeState> Node<'r, T, S> {
     /// - static
     /// - dynamic constrained
     /// - dynamic
-    /// - wildcard contrained
+    /// - wildcard constrained
     /// - wildcard
     /// - end wildcard constrained
     /// - wildcard


### PR DESCRIPTION
Uses the routes with literals as paths now instead.

Turns out some of the old routes were wrong too :sweat_smile: 