### PR TITLE
Update dependencies and benchmarks.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,1 @@
-watch_file flake.lock
-watch_file flake.nix
-
 use flake

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,28 +6,23 @@ inputs:
     description: The Nix flake shell
     required: true
 
-  cachix-auth-token:
-    description: The secret Cachix token
-    required: true
-
 runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@v14
+      uses: nixbuild/nix-quick-install-action@v30
 
-    - name: Setup Cachix
-      uses: cachix/cachix-action@v15
+    - name: Cache Nix
+      uses: nix-community/cache-nix-action@v6
       with:
-        name: dusksystems
-        authToken: ${{ inputs.cachix-auth-token }}
-        extraPullNames: nix-community
+        primary-key: nix-${{ inputs.shell }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ inputs.shell }}-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Configure SCCache
       uses: actions/github-script@v7
       with:
         script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL);
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL);
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN);
 
     - name: Initialize Nix shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
   id-token: write
 
 env:
+  ACTIONS_CACHE_SERVICE_V2: "on"
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_VERSION: "1"
 
@@ -34,7 +35,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: ci
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run checks
         run: |
@@ -61,7 +61,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: ci
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build benchmarks
         run: cargo codspeed build --workspace
@@ -88,7 +87,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: nightly
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Generate coverage
         run: cargo llvm-cov --workspace --doctests --codecov --output-path codecov.json
@@ -115,7 +113,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: msrv
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build wayfind
         run: cargo build --package wayfind
@@ -135,7 +132,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: msrv
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build wayfind
         run: cargo build --package wayfind --target wasm32-unknown-unknown
@@ -155,7 +151,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: ci
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Run OCI tests
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,7 @@ permissions:
   pages: write
 
 env:
+  ACTIONS_CACHE_SERVICE_V2: "on"
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_VERSION: "1"
 
@@ -34,7 +35,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           shell: ci
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,7 @@ report.html
 
 # Nix
 result
-result-dev
-result-man
-result-info
-result-lib
-result-bin
+result-*
 
 # Dir Env
 .direnv

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -37,25 +37,25 @@ In a router of 130 templates, benchmark matching 130 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| matchit          | 5.0940 µs | 1           | 128 B      | 1             | 128 B        |
-| wayfind          | 7.1608 µs | 0           | n/a        | 0             | n/a          |
-| path-tree        | 8.7696 µs | 0           | n/a        | 0             | n/a          |
-| xitca-router     | 13.282 µs | 103         | 13.18 KB   | 103           | 13.18 KB     |
-| ntex-router      | 40.944 µs | 1706        | 173.8 KB   | 406           | 23.87 KB     |
-| route-recognizer | 67.603 µs | 3596        | 195.6 KB   | 3596          | 195.6 KB     |
-| actix-router     | 506.54 µs | 9818        | 1.488 MB   | 7140          | 449.2 KB     |
+| matchit          | 5.4637 µs | 1           | 128 B      | 1             | 128 B        |
+| wayfind          | 7.6363 µs | 0           | n/a        | 0             | n/a          |
+| path-tree        | 8.9698 µs | 0           | n/a        | 0             | n/a          |
+| xitca-router     | 14.138 µs | 103         | 13.18 KB   | 103           | 13.18 KB     |
+| ntex-router      | 43.049 µs | 306         | 22.97 KB   | 306           | 22.97 KB     |
+| route-recognizer | 70.832 µs | 3596        | 195.6 KB   | 3596          | 195.6 KB     |
+| actix-router     | 546.53 µs | 6934        | 447.4 KB   | 6934          | 447.4 KB     |
 
 #### String Parameters
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 8.1992 µs | 0           | n/a        | 0             | n/a          |
-| matchit          | 9.3138 µs | 1           | 128 B      | 1             | 128 B        |
-| path-tree        | 9.7952 µs | 0           | n/a        | 0             | n/a          |
-| xitca-router     | 13.885 µs | 103         | 13.18 KB   | 103           | 13.18 KB     |
-| ntex-router      | 41.460 µs | 1706        | 173.8 KB   | 406           | 23.87 KB     |
-| route-recognizer | 68.661 µs | 3596        | 195.6 KB   | 3596          | 195.6 KB     |
-| actix-router     | 509.55 µs | 9818        | 1.488 MB   | 7140          | 449.2 KB     |
+| wayfind          | 8.9127 µs | 0           | n/a        | 0             | n/a          |
+| matchit          | 10.003 µs | 1           | 128 B      | 1             | 128 B        |
+| path-tree        | 10.059 µs | 0           | n/a        | 0             | n/a          |
+| xitca-router     | 14.882 µs | 103         | 13.18 KB   | 103           | 13.18 KB     |
+| ntex-router      | 43.631 µs | 306         | 22.97 KB   | 306           | 22.97 KB     |
+| route-recognizer | 72.031 µs | 3596        | 195.6 KB   | 3596          | 195.6 KB     |
+| actix-router     | 544.45 µs | 6934        | 447.4 KB   | 6934          | 447.4 KB     |
 
 ### `path-tree` inspired benches
 
@@ -65,25 +65,25 @@ In a router of 320 templates, benchmark matching 80 paths.
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 3.6237 µs | 0           | n/a        | 0             | n/a          |
-| path-tree        | 4.7438 µs | 0           | n/a        | 0             | n/a          |
-| matchit          | 5.6865 µs | 81          | 10.36 KB   | 81            | 10.36 KB     |
-| xitca-router     | 8.6405 µs | 150         | 18.06 KB   | 150           | 18.06 KB     |
-| ntex-router      | 25.330 µs | 1290        | 135.8 KB   | 224           | 12.83 KB     |
-| route-recognizer | 61.766 µs | 2813        | 184.2 KB   | 2813          | 197.4 KB     |
-| actix-router     | 171.85 µs | 3766        | 595.8 KB   | 2258          | 122.4 KB     |
+| wayfind          | 3.9724 µs | 0           | n/a        | 0             | n/a          |
+| path-tree        | 4.9039 µs | 0           | n/a        | 0             | n/a          |
+| matchit          | 6.0203 µs | 81          | 10.36 KB   | 81            | 10.36 KB     |
+| xitca-router     | 9.2584 µs | 150         | 18.06 KB   | 150           | 18.06 KB     |
+| ntex-router      | 26.716 µs | 142         | 12.09 KB   | 142           | 12.09 KB     |
+| route-recognizer | 65.154 µs | 2813        | 184.2 KB   | 2813          | 197.4 KB     |
+| actix-router     | 185.50 µs | 2142        | 121.4 KB   | 2142          | 121.4 KB     |
 
 #### String Parameters
 
 | Library          | Time      | Alloc Count | Alloc Size | Dealloc Count | Dealloc Size |
 |:-----------------|----------:|------------:|-----------:|--------------:|-------------:|
-| wayfind          | 4.2385 µs | 0           | n/a        | 0             | n/a          |
-| path-tree        | 5.2886 µs | 0           | n/a        | 0             | n/a          |
-| matchit          | 7.6726 µs | 81          | 10.36 KB   | 81            | 10.36 KB     |
-| xitca-router     | 8.9593 µs | 150         | 18.06 KB   | 150           | 18.06 KB     |
-| ntex-router      | 25.629 µs | 1290        | 135.8 KB   | 224           | 12.83 KB     |
-| route-recognizer | 62.677 µs | 2813        | 184.2 KB   | 2813          | 197.4 KB     |
-| actix-router     | 172.93 µs | 3766        | 595.8 KB   | 2258          | 122.4 KB     |
+| wayfind          | 4.5999 µs | 0           | n/a        | 0             | n/a          |
+| path-tree        | 5.4243 µs | 0           | n/a        | 0             | n/a          |
+| matchit          | 8.1373 µs | 81          | 10.36 KB   | 81            | 10.36 KB     |
+| xitca-router     | 9.5970 µs | 150         | 18.06 KB   | 150           | 18.06 KB     |
+| ntex-router      | 27.036 µs | 142         | 12.09 KB   | 142           | 12.09 KB     |
+| route-recognizer | 65.873 µs | 2813        | 184.2 KB   | 2813          | 197.4 KB     |
+| actix-router     | 185.70 µs | 2142        | 121.4 KB   | 2142          | 121.4 KB     |
 
 ## `wayfind` benches
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -126,9 +126,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytestring"
@@ -147,9 +147,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -191,18 +191,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -217,9 +217,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codspeed"
-version = "2.8.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d2f5a6570db487f5258e0bded6352fa2034c2aeb46bb5cc3ff060a0fcfba2f"
+checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
 dependencies = [
  "colored",
  "libc",
@@ -230,20 +230,47 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "2.8.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53a55558dedec742b14aae3c5fec389361b8b5ca28c1aadf09dd91faf710074"
+checksum = "c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725"
 dependencies = [
  "codspeed",
+ "codspeed-criterion-compat-walltime",
  "colored",
- "criterion",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a2f7365e347f4f22a67e9ea689bf7bc89900a354e22e26cf8a531a42c8fbb"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
 name = "codspeed-divan-compat"
-version = "2.8.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9da137ea5f911fec2e88f03d6040b36eeebcd66385ebaa041c4d2965778fdb"
+checksum = "8620a09dfaf37b3c45f982c4b65bd8f9b0203944da3ffa705c0fcae6b84655ff"
 dependencies = [
  "codspeed",
  "codspeed-divan-compat-macros",
@@ -252,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-macros"
-version = "2.8.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566adb03248996f1a6d22ddd0fcbf7fb4c9f1b6cc111268e8a0de59e68c238f8"
+checksum = "30fe872bc4214626b35d3a1706a905d0243503bb6ba3bb7be2fc59083d5d680c"
 dependencies = [
  "divan-macros",
  "itertools 0.14.0",
@@ -266,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-walltime"
-version = "2.8.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c75d912d1b2eebbe9be806eaf8baddc6004e2b0483ba0f2047c8b04d8e6c0ae"
+checksum = "104caa97b36d4092d89e24e4b103b40ede1edab03c0372d19e14a33f9393132b"
 dependencies = [
  "cfg-if",
  "clap",
@@ -297,9 +324,9 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -314,32 +341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
 ]
 
 [[package]]
@@ -430,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -442,15 +443,15 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -513,14 +514,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -531,16 +532,16 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -550,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -572,9 +573,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "http"
@@ -589,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -605,27 +606,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -643,7 +644,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -655,13 +656,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -670,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -680,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.42.1"
+version = "1.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
 dependencies = [
  "console",
  "linked-hash-map",
@@ -693,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -722,16 +723,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom",
  "libc",
 ]
 
@@ -753,9 +755,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -775,9 +777,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -791,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchit"
@@ -809,9 +811,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -845,7 +847,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb9c68c26a87ffca54339be5f95223339db3e7bcc5d64733fef20812970a746f"
 dependencies = [
- "http 1.2.0",
+ "http 1.3.1",
  "log",
  "ntex-bytes",
  "regex",
@@ -882,15 +884,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "overload"
@@ -913,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "path-tree"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7fabb0b56aba5d2eb3fa9b1547c187f21f8c051295a7b97a50be6a9332f4cb"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
 dependencies = [
  "smallvec",
 ]
@@ -928,18 +930,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -988,30 +990,36 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rayon"
@@ -1035,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -1091,9 +1099,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -1104,15 +1112,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1131,18 +1139,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1151,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1199,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f08357795f0d604ea7d7130f22c74b03838c959bdb14adde3142aab4d18a293"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
  "console",
  "similar",
@@ -1218,15 +1226,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1234,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix",
  "windows-sys 0.59.0",
@@ -1255,18 +1263,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1295,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1322,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1410,15 +1418,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1428,9 +1436,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom",
 ]
@@ -1465,9 +1473,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -1562,7 +1570,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "dashmap",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1703,18 +1711,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,26 +71,29 @@ new_without_default = "allow"
 str_to_string = "deny"
 too_many_lines = "allow"
 
+# Our templates look similar to formatted strings.
+literal_string_with_formatting_args = "allow"
+
 [dependencies]
 # Data Structures
-smallvec = { version = "1.13", features = ["const_generics", "union"] }
+smallvec = { version = "1.15", features = ["const_generics", "union"] }
 
 [dev-dependencies]
 # Testing
 # NOTE: Keep in sync with `cargo-insta` Nix package.
-insta = "=1.42.1"
-similar-asserts = "1.6"
+insta = "=1.42.2"
+similar-asserts = "1.7"
 
 # Benchmarking
 # NOTE: Keep versions in sync with `cargo-codspeed` Nix package.
-divan = { package = "codspeed-divan-compat", version = "=2.8.0" }
-criterion = { package = "codspeed-criterion-compat", version = "=2.8.0" }
+divan = { package = "codspeed-divan-compat", version = "=2.10.1" }
+criterion = { package = "codspeed-criterion-compat", version = "=2.10.1" }
 
 # Routers
 actix-router = "=0.5.3"
 matchit = "=0.8.6"
 ntex-router = "=0.5.3"
-path-tree = "=0.8.1"
+path-tree = "=0.8.3"
 route-recognizer = "=0.3.1"
 xitca-router = "=0.3.0"
 

--- a/benches/matchit_criterion.rs
+++ b/benches/matchit_criterion.rs
@@ -1,6 +1,8 @@
 //! Benches sourced from `matchit` (MIT AND BSD-3-Clause)
 //! <https://github.com/ibraheemdev/matchit/blob/v0.8.6/benches/bench.rs>
 
+#![allow(clippy::significant_drop_tightening)]
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use smallvec::SmallVec;
 

--- a/benches/path_tree_criterion.rs
+++ b/benches/path_tree_criterion.rs
@@ -1,6 +1,8 @@
 //! Benches sourced from `path-tree` (MIT OR Apache-2.0)
 //! <https://github.com/viz-rs/path-tree/blob/v0.8.1/benches/bench.rs>
 
+#![allow(clippy::significant_drop_tightening)]
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use path_tree_routes::paths;
 use smallvec::SmallVec;

--- a/examples/oci/Cargo.toml
+++ b/examples/oci/Cargo.toml
@@ -50,12 +50,12 @@ too_many_lines = "allow"
 wayfind = { path = "../.." }
 
 # Web
-bytes = "1.5"
-http = "1.0"
+bytes = "1.10"
+http = "1.3"
 http-body-util = "0.1"
-hyper = "1.1"
+hyper = "1.6"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
-tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
 
 # Logging
 tracing = "0.1"
@@ -69,7 +69,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 
 # UUID
-uuid = { version = "1.10", features = ["v4"] }
+uuid = { version = "1.16", features = ["v4"] }
 
 # Hash
 sha2 = "0.10"
@@ -78,7 +78,7 @@ sha2 = "0.10"
 percent-encoding = "2.3"
 
 # Regex
-regex = "1.10"
+regex = "1.11"
 
 # Data Structures
-dashmap = "6.0"
+dashmap = "6.1"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739419412,
-        "narHash": "sha256-NCWZQg4DbYVFWg+MOFrxWRaVsLA7yvRWAf6o0xPR1hI=",
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d55b4c1531187926c2a423f6940b3b1301399b5",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739413688,
-        "narHash": "sha256-57OAXXYhOibG7Rqhhr4ecI1H8mtDJB2uj0T8rbQVGLY=",
+        "lastModified": 1745375696,
+        "narHash": "sha256-zFRCHNRJ1Ei8GD3iP+wcedkJzLo84OO7JEu/gmhSllU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "675a6427d505f140dab8c56379afb66d4f55800b",
+        "rev": "19d1b5002d43c019880dd5cc0f8420efd20d5faf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,7 @@
           inherit system;
 
           overlays = [
-            (import rust-overlay)
-
+            (rust-overlay.overlays.default)
             (final: prev: {
               cargo-codspeed = prev.callPackage ./nix/pkgs/cargo-codspeed { };
               cargo-insta = prev.callPackage ./nix/pkgs/cargo-insta { };
@@ -66,7 +65,7 @@
 
           buildInputs = with pkgs; [
             # Rust
-            (rust-bin.stable."1.84.1".minimal.override {
+            (rust-bin.stable.latest.minimal.override {
               targets = [ "wasm32-unknown-unknown" ];
               extensions = [
                 "clippy"
@@ -107,6 +106,7 @@
             zizmor
 
             # Nix
+            nix-update
             nixfmt-rfc-style
             nixd
             nil
@@ -125,7 +125,7 @@
 
           buildInputs = with pkgs; [
             # Rust
-            (rust-bin.nightly."2025-02-13".minimal.override { extensions = [ "llvm-tools" ]; })
+            (rust-bin.nightly.latest.minimal.override { extensions = [ "llvm-tools" ]; })
             sccache
 
             # Coverage
@@ -171,7 +171,7 @@
 
           buildInputs = with pkgs; [
             # Rust
-            (rust-bin.stable."1.84.1".minimal.override {
+            (rust-bin.stable.latest.minimal.override {
               extensions = [
                 "clippy"
                 "rustfmt"
@@ -189,13 +189,8 @@
       });
 
       packages = perSystemPkgs (pkgs: {
-        # nix build .#cargo-codspeed
         cargo-codspeed = pkgs.cargo-codspeed;
-
-        # nix build .#cargo-insta
         cargo-insta = pkgs.cargo-insta;
-
-        # nix build .#oci-conformance
         oci-conformance = pkgs.oci-conformance;
       });
     };

--- a/nix/pkgs/cargo-codspeed/default.nix
+++ b/nix/pkgs/cargo-codspeed/default.nix
@@ -10,15 +10,15 @@ rustPlatform.buildRustPackage rec {
   pname = "cargo-codspeed";
 
   # NOTE: Keep in sync with `codspeed-*-compat` Rust packages.
-  version = "2.8.0";
+  version = "2.10.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-JchV9nnaY/Kvq2FIuDrgg/rLdn9h8AWVdUiD/brOdWU=";
+    hash = "sha256-tgMOqi2XGbKTDrVQ3Op+m4DBAUAITIB+GibjaQ8x/MI=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-1XXh5S2qElsx4M/ag8BvqFaMhb8zQEPiekPsWyRv1mY=";
+  cargoHash = "sha256-YGmnz9P2S0baENC9lP1qMMLSzv2lUbvyjcl8FWpDvZ0=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];

--- a/nix/pkgs/cargo-insta/default.nix
+++ b/nix/pkgs/cargo-insta/default.nix
@@ -8,15 +8,15 @@ rustPlatform.buildRustPackage rec {
   pname = "cargo-insta";
 
   # NOTE: Keep in sync with `cargo-insta` Rust package.
-  version = "1.42.1";
+  version = "1.42.2";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-qAe3GhGcXlzmt73M/sCdUAlSCYrEaaJbxmCf4fVk6Tg=";
+    hash = "sha256-bsLV+iQYbqOv+OftOPAt/89vZ738GgnNlHt1JNAc+m0=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-hoMAssMikg6RmNYEMxsBXXhQ5zPUSMOJh9t8mtkF8ZQ=";
+  cargoHash = "sha256-bdioXT3Bm+BnSRiMW9M7b587KceVFLqeJ+N8+x9+0sE=";
 
   doCheck = false;
 

--- a/nix/pkgs/oci-conformance/default.nix
+++ b/nix/pkgs/oci-conformance/default.nix
@@ -6,17 +6,17 @@
 
 buildGoModule rec {
   pname = "oci-conformance";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "opencontainers";
     repo = "distribution-spec";
     rev = "v${version}";
-    hash = "sha256-GL28YUwDRicxS65E7SDR/Q3tJOWN4iwgq4AGBjwVPzA=";
+    hash = "sha256-cD5/9vwqcgI1ZIbIfnS3xdv806SCK1KCcNe/UYToWWk=";
   };
 
   sourceRoot = "source/conformance";
-  vendorHash = "sha256-5gn9RpjCALZB/GFjlJHDqPs2fIHl7NJr5QjPmsLnnO4=";
+  vendorHash = "sha256-OYNnPlWc3IvqGl9L8zO60vaq+2bUtK/uP31cDgXw8u4=";
 
   env = {
     CGO_ENABLED = 0;

--- a/src/node.rs
+++ b/src/node.rs
@@ -60,6 +60,7 @@ impl<T> NodeData<T> {
         }
     }
 
+    #[allow(clippy::missing_const_for_fn)]
     pub fn template(&self) -> &str {
         match self {
             Self::Inline { template, .. } | Self::Shared { template, .. } => template,
@@ -67,6 +68,7 @@ impl<T> NodeData<T> {
     }
 
     #[inline]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn expanded(&self) -> Option<&str> {
         match self {
             Self::Inline { .. } => None,

--- a/src/node/insert.rs
+++ b/src/node/insert.rs
@@ -33,7 +33,7 @@ impl<T, S: NodeState> Node<T, S> {
                     self.insert_wildcard_constrained(template, data, name, constraint);
                 }
                 Part::Wildcard { name } => self.insert_wildcard(template, data, name),
-            };
+            }
         } else {
             self.data = Some(data);
             self.needs_optimization = true;
@@ -119,7 +119,7 @@ impl<T, S: NodeState> Node<T, S> {
 
             self.needs_optimization = true;
             return;
-        };
+        }
 
         self.static_children.push({
             let mut new_child = Node {

--- a/src/router.rs
+++ b/src/router.rs
@@ -240,7 +240,7 @@ impl<T> Router<T> {
                     length,
                 },
             );
-        };
+        }
 
         self.root.optimize();
         Ok(())
@@ -292,7 +292,7 @@ impl<T> Router<T> {
                 return Err(DeleteError::NotFound {
                     template: template.to_owned(),
                 });
-            };
+            }
         }
 
         let mut output = None;


### PR DESCRIPTION
- Ditch Cachix
- Update Cargo dependencies to latest
- Update Nix packages to latest
- Resolve new Clippy lints
- Update benchmark results