### PR TITLE
chore: Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0](https://github.com/DuskSystems/wayfind/compare/v0.9.1...v1.0.0) - 2026-04-04
+
+### Other
+
+- Bump major version
+
 ## [0.9.1](https://github.com/DuskSystems/wayfind/compare/v0.9.0...v0.9.1) - 2026-04-04
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `wayfind`: 0.9.1 -> 1.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0](https://github.com/DuskSystems/wayfind/compare/v0.9.1...v1.0.0) - 2026-04-04

### Other

- Bump major version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).