### PR TITLE
chore: Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1](https://github.com/DuskSystems/wayfind/compare/v1.0.0...v1.0.1) - 2026-05-11
+
+### Other
+
+- Clean up internals
+- Smarter reachability pruning
+- Update dependencies
+
 ## [1.0.0](https://github.com/DuskSystems/wayfind/compare/v0.9.1...v1.0.0) - 2026-04-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "wayfind"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "actix-router",
  "codspeed-divan-compat",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "wayfind-fuzz"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "libfuzzer-sys",
  "wayfind",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 members = [".", "fuzz"]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.85"
 repository = "https://github.com/DuskSystems/wayfind"


### PR DESCRIPTION



## 🤖 New release

* `wayfind`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/DuskSystems/wayfind/compare/v1.0.0...v1.0.1) - 2026-05-11

### Other

- Clean up internals
- Smarter reachability pruning
- Update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).