### PR TITLE
chore: Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0](https://github.com/SwornSystems/wayfind/compare/v1.0.3...v1.1.0) - 2026-08-01
+
+### Features
+- Rename DuskSystems to SwornSystems ([0a9a891](https://github.com/SwornSystems/wayfind/commit/0a9a8919572de4273b475d5d2521a59d7e88b15a))
+
 ## [1.0.3](https://github.com/SwornSystems/wayfind/compare/v1.0.2...v1.0.3) - 2026-06-13
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wayfind"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "actix-router",
  "codspeed-divan-compat",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "wayfind-fuzz"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "libfuzzer-sys",
  "wayfind",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 members = [".", "fuzz"]
 
 [workspace.package]
-version = "1.0.3"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.85"
 repository = "https://github.com/SwornSystems/wayfind"


### PR DESCRIPTION



## 🤖 New release

* `wayfind`: 1.0.3 -> 1.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/SwornSystems/wayfind/compare/v1.0.3...v1.1.0) - 2026-08-01

### Features
- Rename DuskSystems to SwornSystems ([0a9a891](https://github.com/SwornSystems/wayfind/commit/0a9a8919572de4273b475d5d2521a59d7e88b15a))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).